### PR TITLE
feat: read-only CLI admin tool (bin/admin.php)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .env
 .phpunit.cache/
 .claude/settings.local.json
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,14 @@ php vendor/bin/phpunit
 
 # Cleanup cron (expires bundles, sessions, flagged accounts)
 php bin/cleanup.php
+
+# Admin dashboard (read-only DB inspection)
+php bin/admin.php              # Full dashboard
+php bin/admin.php accounts     # Account details
+php bin/admin.php bundles      # Bundle/workspace details
+php bin/admin.php sessions     # Session/challenge/reset details
+php bin/admin.php invites      # Invite details
+php bin/admin.php health       # System health + settings
 ```
 
 ## Project layout

--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ php bin/install.php
 php -S localhost:8080 -t public/ public/index.php
 ```
 
+## Admin tool
+
+A read-only CLI tool for inspecting the live database and storage:
+
+```bash
+php bin/admin.php              # Full dashboard (all sections)
+php bin/admin.php accounts     # Account list with device counts, storage, and flagged status
+php bin/admin.php bundles      # Pending bundles grouped by workspace
+php bin/admin.php sessions     # Active sessions, pending challenges, unused password resets
+php bin/admin.php invites      # Active invites with download counts
+php bin/admin.php health       # DB pragmas, migration status, storage sizes, and settings
+php bin/admin.php help         # Show usage
+```
+
 ## API overview
 
 > **Full reference:** [`docs/api.md`](docs/api.md) — every endpoint with request/response fields, error codes, and the PoP handshake protocol.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ php -S localhost:8080 -t public/ public/index.php
 
 ## API overview
 
+> **Full reference:** [`docs/api.md`](docs/api.md) — every endpoint with request/response fields, error codes, and the PoP handshake protocol.
+
 All request and response bodies are JSON. Authenticated endpoints require a `Bearer` token in the `Authorization` header.
 
 ### Authentication

--- a/bin/admin.php
+++ b/bin/admin.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * CLI admin tool for inspecting the relay database and storage.
+ *
+ * Usage:
+ *   php bin/admin.php              Full dashboard
+ *   php bin/admin.php accounts     Account details
+ *   php bin/admin.php bundles      Bundle/workspace details
+ *   php bin/admin.php sessions     Session, challenge, and reset details
+ *   php bin/admin.php invites      Invite details
+ *   php bin/admin.php health       System health
+ *   php bin/admin.php help         Show this help
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Relay\Database\Connection;
+
+// ── Helper functions ────────────────────────────────────────────────
+
+function humanBytes(int $bytes): string
+{
+    if ($bytes === 0) {
+        return '0 B';
+    }
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $i = 0;
+    $value = (float) $bytes;
+    while ($value >= 1024 && $i < count($units) - 1) {
+        $value /= 1024;
+        $i++;
+    }
+    return $i === 0
+        ? "{$bytes} B"
+        : sprintf('%.1f %s', $value, $units[$i]);
+}
+
+function relativeTime(?string $timestamp): string
+{
+    if ($timestamp === null) {
+        return 'never';
+    }
+    $diff = time() - strtotime($timestamp);
+    if ($diff < 60) {
+        return 'just now';
+    }
+    if ($diff < 3600) {
+        return intdiv($diff, 60) . 'm ago';
+    }
+    if ($diff < 86400) {
+        return intdiv($diff, 3600) . 'h ago';
+    }
+    return intdiv($diff, 86400) . 'd ago';
+}
+
+function relativeTimeFuture(string $timestamp): string
+{
+    $diff = strtotime($timestamp) - time();
+    if ($diff < 0) {
+        $ago = abs($diff);
+        if ($ago < 3600) {
+            return 'expired ' . intdiv($ago, 60) . 'm ago!';
+        }
+        if ($ago < 86400) {
+            return 'expired ' . intdiv($ago, 3600) . 'h ago!';
+        }
+        return 'expired ' . intdiv($ago, 86400) . 'd ago!';
+    }
+    if ($diff < 3600) {
+        return 'in ' . intdiv($diff, 60) . 'm';
+    }
+    if ($diff < 86400) {
+        return 'in ' . intdiv($diff, 3600) . 'h';
+    }
+    return 'in ' . intdiv($diff, 86400) . 'd';
+}
+
+function progressBar(int $current, int $max): string
+{
+    $pct = $max > 0 ? (int) round($current / $max * 100) : 0;
+    return humanBytes($current) . ' / ' . humanBytes($max) . " ({$pct}%)";
+}
+
+// ── Table formatter ─────────────────────────────────────────────────
+
+function printTable(array $headers, array $rows): void
+{
+    if (empty($rows)) {
+        echo "  (none)\n";
+        return;
+    }
+
+    // Calculate column widths
+    $widths = [];
+    foreach ($headers as $i => $header) {
+        $widths[$i] = mb_strlen($header);
+    }
+    foreach ($rows as $row) {
+        foreach (array_values($row) as $i => $cell) {
+            $widths[$i] = max($widths[$i] ?? 0, mb_strlen((string) $cell));
+        }
+    }
+
+    // Print header
+    $line = '  ';
+    foreach ($headers as $i => $header) {
+        $line .= str_pad($header, $widths[$i] + 2);
+    }
+    echo $line . "\n";
+    echo '  ' . str_repeat('─', array_sum($widths) + count($widths) * 2) . "\n";
+
+    // Print rows
+    foreach ($rows as $row) {
+        $line = '  ';
+        foreach (array_values($row) as $i => $cell) {
+            $line .= str_pad((string) $cell, $widths[$i] + 2);
+        }
+        echo $line . "\n";
+    }
+}
+
+// ── Section stubs (to be implemented in subsequent tasks) ───────────
+// All functions MUST be defined before the PHPUNIT_RUNNING guard so
+// they are available when the file is loaded from tests.
+
+function showAccounts(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Accounts: (not yet implemented)\n";
+}
+
+function showBundles(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Bundles: (not yet implemented)\n";
+}
+
+function showSessions(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Sessions: (not yet implemented)\n";
+}
+
+function showInvites(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Invites: (not yet implemented)\n";
+}
+
+function showHealth(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Health: (not yet implemented)\n";
+}
+
+function showHelp(): void
+{
+    echo <<<HELP
+    swarm-relay admin tool
+
+    Usage: php bin/admin.php [command]
+
+    Commands:
+      (none)     Full dashboard (all sections)
+      accounts   Account details
+      bundles    Bundle/workspace details
+      sessions   Session, challenge, and reset details
+      invites    Invite details
+      health     System health — DB, storage, migrations, settings
+      help       Show this help
+
+    HELP;
+}
+
+// ── Guard: skip dispatch when loaded from tests ─────────────────────
+
+if (defined('PHPUNIT_RUNNING')) {
+    return;
+}
+
+// ── Bootstrap ───────────────────────────────────────────────────────
+
+$settings = require __DIR__ . '/../config/settings.php';
+$pdo = Connection::create($settings['database']['path']);
+
+// ── Dispatch ────────────────────────────────────────────────────────
+
+$command = $argv[1] ?? 'dashboard';
+
+switch ($command) {
+    case 'dashboard':
+        showAccounts($pdo, $settings, false);
+        showBundles($pdo, $settings, false);
+        showSessions($pdo, $settings, false);
+        showInvites($pdo, $settings, false);
+        showHealth($pdo, $settings, false);
+        break;
+    case 'accounts':
+        showAccounts($pdo, $settings, true);
+        break;
+    case 'bundles':
+        showBundles($pdo, $settings, true);
+        break;
+    case 'sessions':
+        showSessions($pdo, $settings, true);
+        break;
+    case 'invites':
+        showInvites($pdo, $settings, true);
+        break;
+    case 'health':
+        showHealth($pdo, $settings, true);
+        break;
+    case 'help':
+        showHelp();
+        break;
+    default:
+        echo "Unknown command: {$command}\n\n";
+        showHelp();
+        exit(1);
+}

--- a/bin/admin.php
+++ b/bin/admin.php
@@ -280,7 +280,93 @@ function showBundles(\PDO $pdo, array $settings, bool $detailed): void
 
 function showSessions(\PDO $pdo, array $settings, bool $detailed): void
 {
-    echo "Sessions: (not yet implemented)\n";
+    // Summary stats
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            MIN(created_at) as oldest,
+            MIN(expires_at) as soonest_expiry,
+            COUNT(DISTINCT account_id) as account_count
+         FROM sessions
+         WHERE expires_at > datetime('now')"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $accountCount = (int) $stats['account_count'];
+
+    $oldestStr = '';
+    if ($stats['oldest']) {
+        $oldestStr = ', oldest: ' . relativeTime($stats['oldest'])
+            . ' (' . relativeTimeFuture($stats['soonest_expiry']) . ')';
+    }
+
+    echo "Sessions: {$total} active{$oldestStr}, {$accountCount} accounts with active sessions\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Per-account detail
+    $rows = $pdo->query(
+        "SELECT
+            a.email,
+            COUNT(s.token) as session_count,
+            MAX(s.created_at) as newest,
+            MIN(s.created_at) as oldest,
+            MIN(s.expires_at) as soonest_expiry
+         FROM sessions s
+         JOIN accounts a ON a.account_id = s.account_id
+         WHERE s.expires_at > datetime('now')
+         GROUP BY s.account_id
+         ORDER BY session_count DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        $tableRows[] = [
+            'account'  => $row['email'],
+            'sessions' => (string) $row['session_count'],
+            'newest'   => relativeTime($row['newest']),
+            'oldest'   => relativeTime($row['oldest']),
+            'expires'  => relativeTimeFuture($row['soonest_expiry']),
+        ];
+    }
+
+    echo "\n";
+    printTable(['Account', 'Sessions', 'Newest', 'Oldest', 'Expires'], $tableRows);
+
+    // Challenge summary
+    $challenges = $pdo->query(
+        "SELECT context, COUNT(*) as cnt, MIN(created_at) as oldest
+         FROM challenges
+         WHERE expires_at > datetime('now')
+         GROUP BY context"
+    )->fetchAll();
+
+    $totalChallenges = array_sum(array_column($challenges, 'cnt'));
+    if ($totalChallenges > 0) {
+        $parts = array_map(fn($c) => "{$c['cnt']} {$c['context']}", $challenges);
+        $oldest = min(array_column($challenges, 'oldest'));
+        echo "\nChallenges: {$totalChallenges} pending (" . implode(', ', $parts)
+            . '), oldest: ' . relativeTime($oldest) . "\n";
+    } else {
+        echo "\nChallenges: 0 pending\n";
+    }
+
+    // Password reset summary
+    $resets = $pdo->query(
+        "SELECT COUNT(*) as cnt, MIN(expires_at) as soonest
+         FROM password_resets
+         WHERE used = 0 AND expires_at > datetime('now')"
+    )->fetch();
+
+    $resetCount = (int) $resets['cnt'];
+    if ($resetCount > 0) {
+        echo "Password resets: {$resetCount} unused, expires "
+            . relativeTimeFuture($resets['soonest']) . "\n";
+    } else {
+        echo "Password resets: 0 unused\n";
+    }
 }
 
 function showInvites(\PDO $pdo, array $settings, bool $detailed): void

--- a/bin/admin.php
+++ b/bin/admin.php
@@ -429,7 +429,98 @@ function showInvites(\PDO $pdo, array $settings, bool $detailed): void
 
 function showHealth(\PDO $pdo, array $settings, bool $detailed): void
 {
-    echo "Health: (not yet implemented)\n";
+    $migrationsPath = dirname(__DIR__) . '/migrations';
+    $dbPath = $settings['database']['path'];
+    $bundlesPath = $settings['storage']['bundles_path'];
+    $invitesPath = $settings['storage']['invites_path'];
+
+    // Migration count
+    $migrationFiles = glob($migrationsPath . '/*.sql');
+    $totalMigrations = count($migrationFiles);
+    $appliedMigrations = (int) $pdo->query('SELECT COUNT(*) FROM _migrations')->fetchColumn();
+
+    $migrationStr = "{$appliedMigrations}/{$totalMigrations} migrations applied";
+    if ($appliedMigrations < $totalMigrations) {
+        $pending = $totalMigrations - $appliedMigrations;
+        $migrationStr .= " ⚠ {$pending} pending";
+    }
+
+    // Pragma checks
+    $journalMode = $pdo->query('PRAGMA journal_mode')->fetchColumn();
+    $foreignKeys = $pdo->query('PRAGMA foreign_keys')->fetchColumn();
+
+    // File sizes
+    $dbSize = file_exists($dbPath) ? filesize($dbPath) : 0;
+    $bundlesDiskSize = dirSize($bundlesPath);
+    $bundlesFileCount = dirFileCount($bundlesPath);
+    $invitesDiskSize = dirSize($invitesPath);
+    $invitesFileCount = dirFileCount($invitesPath);
+
+    // Dashboard line
+    $journalOk = strtolower($journalMode) === 'wal' ? 'WAL ok' : "journal: {$journalMode}";
+    echo "Health: DB " . humanBytes($dbSize) . ", blobs " . humanBytes($bundlesDiskSize)
+        . ", invites " . humanBytes($invitesDiskSize)
+        . ", {$migrationStr}, {$journalOk}\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Detail view
+    $journalCheck = strtolower($journalMode) === 'wal' ? 'WAL ✓' : "{$journalMode} ⚠";
+    $fkCheck = $foreignKeys ? 'ON ✓' : 'OFF ⚠';
+
+    echo "\n=== DATABASE ===\n";
+    echo "  File:          " . (file_exists($dbPath) ? "{$dbPath} (" . humanBytes($dbSize) . ")" : '(in-memory)') . "\n";
+    echo "  Journal:       {$journalCheck}\n";
+    echo "  Foreign keys:  {$fkCheck}\n";
+    echo "  Migrations:    {$appliedMigrations}/{$totalMigrations} applied";
+    if ($appliedMigrations < $totalMigrations) {
+        $pending = $totalMigrations - $appliedMigrations;
+        echo " ⚠ {$pending} pending";
+    }
+    echo "\n";
+
+    echo "\n=== STORAGE ===\n";
+    echo "  Bundles dir:   " . humanBytes($bundlesDiskSize) . " ({$bundlesFileCount} files)\n";
+    echo "  Invites dir:   " . humanBytes($invitesDiskSize) . " ({$invitesFileCount} files)\n";
+    echo "  Total disk:    " . humanBytes($bundlesDiskSize + $invitesDiskSize) . "\n";
+
+    echo "\n=== SETTINGS ===\n";
+    echo "  Bundle retention:     {$settings['limits']['bundle_retention_days']} days\n";
+    echo "  Session lifetime:     " . intdiv($settings['auth']['session_lifetime_seconds'], 86400) . " days\n";
+    echo "  Challenge lifetime:   " . intdiv($settings['auth']['challenge_lifetime_seconds'], 60) . " minutes\n";
+    echo "  Reset token lifetime: " . intdiv($settings['auth']['reset_token_lifetime_seconds'], 3600) . " hour(s)\n";
+    echo "  Max bundle size:      " . humanBytes($settings['limits']['max_bundle_size_bytes']) . "\n";
+    echo "  Max storage/account:  " . humanBytes($settings['limits']['max_storage_per_account_bytes']) . "\n";
+    echo "  Deletion grace:       {$settings['limits']['account_deletion_grace_days']} days\n";
+    echo "  Min poll interval:    {$settings['limits']['min_poll_interval_seconds']} seconds\n";
+}
+
+function dirSize(string $path): int
+{
+    if (!is_dir($path)) {
+        return 0;
+    }
+    $size = 0;
+    foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $file) {
+        $size += $file->getSize();
+    }
+    return $size;
+}
+
+function dirFileCount(string $path): int
+{
+    if (!is_dir($path)) {
+        return 0;
+    }
+    $count = 0;
+    foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $file) {
+        if ($file->isFile()) {
+            $count++;
+        }
+    }
+    return $count;
 }
 
 function showHelp(): void

--- a/bin/admin.php
+++ b/bin/admin.php
@@ -128,7 +128,62 @@ function printTable(array $headers, array $rows): void
 
 function showAccounts(\PDO $pdo, array $settings, bool $detailed): void
 {
-    echo "Accounts: (not yet implemented)\n";
+    $maxStorage = $settings['limits']['max_storage_per_account_bytes'];
+
+    // Summary stats
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            SUM(CASE WHEN flagged_for_deletion IS NOT NULL THEN 1 ELSE 0 END) as flagged,
+            SUM(storage_used) as total_storage
+         FROM accounts"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $flagged = (int) $stats['flagged'];
+    $totalStorage = (int) $stats['total_storage'];
+
+    echo "Accounts: {$total} total, {$flagged} flagged for deletion, "
+        . humanBytes($totalStorage) . " total storage used\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Detail table
+    $rows = $pdo->query(
+        "SELECT
+            a.email,
+            a.storage_used,
+            a.flagged_for_deletion,
+            a.created_at,
+            a.last_poll_at,
+            COUNT(dk.id) as device_total,
+            SUM(CASE WHEN dk.verified = 1 THEN 1 ELSE 0 END) as device_verified
+         FROM accounts a
+         LEFT JOIN device_keys dk ON dk.account_id = a.account_id
+         GROUP BY a.account_id
+         ORDER BY a.created_at DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        $flaggedStr = $row['flagged_for_deletion']
+            ? 'yes (' . relativeTime($row['flagged_for_deletion']) . ')'
+            : '—';
+
+        $tableRows[] = [
+            'email'    => $row['email'],
+            'devices'  => $row['device_total'] . ' (' . (int) $row['device_verified'] . ' verified)',
+            'storage'  => progressBar((int) $row['storage_used'], $maxStorage),
+            'flagged'  => $flaggedStr,
+            'created'  => relativeTime($row['created_at']),
+            'lastPoll' => relativeTime($row['last_poll_at']),
+        ];
+    }
+
+    echo "\n";
+    printTable(['Email', 'Devices', 'Storage', 'Flagged', 'Created', 'Last Poll'], $tableRows);
 }
 
 function showBundles(\PDO $pdo, array $settings, bool $detailed): void

--- a/bin/admin.php
+++ b/bin/admin.php
@@ -371,7 +371,60 @@ function showSessions(\PDO $pdo, array $settings, bool $detailed): void
 
 function showInvites(\PDO $pdo, array $settings, bool $detailed): void
 {
-    echo "Invites: (not yet implemented)\n";
+    // Summary stats (only non-expired invites)
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            COALESCE(SUM(size_bytes), 0) as total_size,
+            COALESCE(SUM(download_count), 0) as total_downloads
+         FROM invites
+         WHERE expires_at > datetime('now')"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $totalSize = (int) $stats['total_size'];
+    $totalDownloads = (int) $stats['total_downloads'];
+
+    echo "Invites: {$total} active, " . humanBytes($totalSize)
+        . " on disk, {$totalDownloads} total downloads\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Detail table
+    $rows = $pdo->query(
+        "SELECT
+            i.token,
+            a.email,
+            i.size_bytes,
+            i.download_count,
+            i.created_at,
+            i.expires_at
+         FROM invites i
+         JOIN accounts a ON a.account_id = i.account_id
+         WHERE i.expires_at > datetime('now')
+         ORDER BY i.created_at DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        $tokenDisplay = strlen($row['token']) > 11
+            ? substr($row['token'], 0, 8) . '...'
+            : $row['token'];
+
+        $tableRows[] = [
+            'token'     => $tokenDisplay,
+            'account'   => $row['email'],
+            'size'      => humanBytes((int) $row['size_bytes']),
+            'downloads' => (string) $row['download_count'],
+            'created'   => relativeTime($row['created_at']),
+            'expires'   => relativeTimeFuture($row['expires_at']),
+        ];
+    }
+
+    echo "\n";
+    printTable(['Token', 'Account', 'Size', 'Downloads', 'Created', 'Expires'], $tableRows);
 }
 
 function showHealth(\PDO $pdo, array $settings, bool $detailed): void

--- a/bin/admin.php
+++ b/bin/admin.php
@@ -188,7 +188,94 @@ function showAccounts(\PDO $pdo, array $settings, bool $detailed): void
 
 function showBundles(\PDO $pdo, array $settings, bool $detailed): void
 {
-    echo "Bundles: (not yet implemented)\n";
+    $retentionDays = $settings['limits']['bundle_retention_days'];
+
+    // Summary stats
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            COALESCE(SUM(size_bytes), 0) as total_size,
+            MIN(created_at) as oldest_created
+         FROM bundles"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $totalSize = (int) $stats['total_size'];
+    $oldestCreated = $stats['oldest_created'];
+
+    $oldestStr = '';
+    if ($oldestCreated) {
+        $oldestStr = ', oldest: ' . relativeTime($oldestCreated);
+        // Compute expiry of oldest bundle
+        $expiresAt = date('Y-m-d H:i:s', strtotime($oldestCreated) + $retentionDays * 86400);
+        $oldestStr .= ' (' . relativeTimeFuture($expiresAt) . ')';
+    }
+
+    echo "Bundles: " . number_format($total) . " pending, "
+        . humanBytes($totalSize) . " on disk{$oldestStr}\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Per-workspace detail with first member lookup
+    $rows = $pdo->query(
+        "SELECT
+            b.workspace_id,
+            COUNT(*) as bundle_count,
+            SUM(b.size_bytes) as total_size,
+            MIN(b.created_at) as oldest,
+            MAX(b.created_at) as newest,
+            GROUP_CONCAT(b.mode) as modes
+         FROM bundles b
+         GROUP BY b.workspace_id
+         ORDER BY bundle_count DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        // Find first member
+        $member = $pdo->prepare(
+            "SELECT a.email
+             FROM mailboxes m
+             JOIN accounts a ON a.account_id = m.account_id
+             WHERE m.workspace_id = ?
+             ORDER BY m.registered_at ASC
+             LIMIT 1"
+        );
+        $member->execute([$row['workspace_id']]);
+        $firstMember = $member->fetchColumn() ?: '(unknown)';
+
+        // Mode breakdown
+        $modeList = explode(',', $row['modes']);
+        $modeCounts = array_count_values($modeList);
+        $modeStr = implode(', ', array_map(
+            fn($count, $mode) => "{$count} {$mode}",
+            $modeCounts,
+            array_keys($modeCounts)
+        ));
+
+        // Truncate workspace ID
+        $wsDisplay = strlen($row['workspace_id']) > 11
+            ? substr($row['workspace_id'], 0, 8) . '...'
+            : $row['workspace_id'];
+
+        $tableRows[] = [
+            'workspace'   => $wsDisplay,
+            'firstMember' => $firstMember,
+            'bundles'     => (string) $row['bundle_count'],
+            'size'        => humanBytes((int) $row['total_size']),
+            'oldest'      => relativeTime($row['oldest']),
+            'newest'      => relativeTime($row['newest']),
+            'modes'       => $modeStr,
+        ];
+    }
+
+    echo "\n";
+    printTable(
+        ['Workspace', 'First Member', 'Bundles', 'Size', 'Oldest', 'Newest', 'Modes'],
+        $tableRows
+    );
 }
 
 function showSessions(\PDO $pdo, array $settings, bool $detailed): void

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,722 @@
+# swarm-relay API Reference
+
+**Base URL:** `https://swarm.krillnotes.org`
+
+All request and response bodies use `Content-Type: application/json` unless stated otherwise. All responses follow one of two envelope shapes:
+
+```json
+{ "data": { ... } }        // success
+{ "error": { "code": "SNAKE_CASE_CODE", "message": "Human-readable description" } }
+```
+
+---
+
+## Authentication
+
+Authenticated endpoints require a session token obtained via `/auth/login` or `/auth/register/verify`:
+
+```
+Authorization: Bearer <session_token>
+```
+
+Tokens expire after 30 days. A missing or invalid token returns:
+
+```json
+HTTP 401
+{ "error": { "code": "UNAUTHORIZED", "message": "Missing authorization header" } }
+```
+
+---
+
+## Proof-of-Possession (PoP) Handshake
+
+Registration and adding a new device both require a cryptographic PoP challenge. The relay encrypts a random nonce to the client's Ed25519 public key (converted to X25519 via `crypto_sign_ed25519_pk_to_curve25519`) using an ephemeral `crypto_box` keypair. The client must decrypt it and return the plaintext.
+
+**Decryption steps (libsodium):**
+1. Convert your Ed25519 secret key → X25519: `crypto_sign_ed25519_sk_to_curve25519(edSk)`
+2. Build a box keypair: `crypto_box_keypair_from_secretkey_and_publickey(x25519Sk, hex2bin(server_public_key))`
+3. Split `encrypted_nonce` (hex): first `CRYPTO_BOX_NONCEBYTES` (24) bytes = box nonce; remainder = ciphertext
+4. Decrypt: `crypto_box_open(ciphertext, boxNonce, keypair)` → plaintext nonce (32 bytes)
+5. Submit the result as a 64-character hex string
+
+---
+
+## Endpoints
+
+### Authentication
+
+---
+
+#### `POST /auth/register`
+
+Begin account registration. Creates the account and first device key, then returns a PoP challenge.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `email` | string | ✓ | Must be unique |
+| `password` | string | ✓ | Stored as bcrypt hash |
+| `identity_uuid` | string | ✓ | Client-generated identifier for this identity |
+| `device_public_key` | string | ✓ | 64-char hex Ed25519 public key (32 bytes) |
+
+```json
+{
+  "email": "alice@example.com",
+  "password": "correct-horse-battery",
+  "identity_uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "device_public_key": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+}
+```
+
+**Response `201`**
+
+```json
+{
+  "data": {
+    "account_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "challenge": {
+      "encrypted_nonce": "a1b2c3d4...",
+      "server_public_key": "e5f6a7b8..."
+    }
+  }
+}
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | Any required field absent |
+| 400 | `INVALID_DEVICE_KEY` | Not a 64-char hex string |
+| 409 | `EMAIL_EXISTS` | Email already registered |
+
+---
+
+#### `POST /auth/register/verify`
+
+Submit the decrypted nonce to prove key ownership. Marks the device as verified and issues a session token.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `device_public_key` | string | ✓ | Same key sent to `/auth/register` |
+| `nonce` | string | ✓ | 64-char hex — plaintext nonce decrypted from challenge |
+
+```json
+{
+  "device_public_key": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+  "nonce": "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00"
+}
+```
+
+**Response `200`**
+
+```json
+{
+  "data": {
+    "account_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "session_token": "3d0a7e5b9c2f1a4d..."
+  }
+}
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | Any required field absent |
+| 404 | `NO_CHALLENGE` | No pending registration challenge for this key |
+| 403 | `INVALID_NONCE` | Decrypted value does not match stored nonce |
+
+---
+
+#### `POST /auth/login`
+
+Password login. Returns a new session token.
+
+**Request body**
+
+| Field | Type | Required |
+|-------|------|----------|
+| `email` | string | ✓ |
+| `password` | string | ✓ |
+
+```json
+{ "email": "alice@example.com", "password": "correct-horse-battery" }
+```
+
+**Response `200`**
+
+```json
+{ "data": { "session_token": "3d0a7e5b9c2f1a4d..." } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | Any required field absent |
+| 401 | `INVALID_CREDENTIALS` | Wrong email or password |
+| 403 | `ACCOUNT_DELETED` | Account is flagged for deletion |
+
+---
+
+#### `POST /auth/logout`  🔒
+
+Invalidates the current session token.
+
+**Request body:** none
+
+**Response `200`**
+
+```json
+{ "data": { "ok": true } }
+```
+
+---
+
+#### `POST /auth/reset-password`
+
+Requests a password reset. Always returns `200` regardless of whether the email exists (prevents enumeration). The reset token is stored server-side; email delivery is not yet implemented.
+
+**Request body**
+
+| Field | Type | Required |
+|-------|------|----------|
+| `email` | string | ✓ |
+
+**Response `200`** (always)
+
+```json
+{ "data": { "message": "If the email exists, a reset link has been sent" } }
+```
+
+---
+
+#### `POST /auth/reset-password/confirm`
+
+Sets a new password using a valid reset token. Tokens expire after 1 hour and are single-use.
+
+**Request body**
+
+| Field | Type | Required |
+|-------|------|----------|
+| `token` | string | ✓ | Reset token from `/auth/reset-password` |
+| `new_password` | string | ✓ | |
+
+```json
+{ "token": "abc123...", "new_password": "new-secure-password" }
+```
+
+**Response `200`**
+
+```json
+{ "data": { "ok": true } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | Any required field absent |
+| 404 | `INVALID_TOKEN` | Token not found or expired |
+
+---
+
+### Account & Devices
+
+---
+
+#### `GET /account`  🔒
+
+Returns account info, all registered device keys, and current storage usage.
+
+**Response `200`**
+
+```json
+{
+  "data": {
+    "account_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "email": "alice@example.com",
+    "identity_uuid": "550e8400-e29b-41d4-a716-446655440000",
+    "role": "user",
+    "device_keys": [
+      {
+        "device_public_key": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "verified": true,
+        "added_at": "2026-01-15 10:30:00"
+      }
+    ],
+    "storage_used": 1048576,
+    "flagged_for_deletion": null,
+    "created_at": "2026-01-15 10:29:00"
+  }
+}
+```
+
+---
+
+#### `DELETE /account`  🔒
+
+Flags the account for deletion. The account and all associated data are permanently deleted after the 90-day grace period by the cleanup cron. The account can be reactivated by logging in again before the grace period expires.
+
+**Response `200`**
+
+```json
+{ "data": { "message": "Account flagged for deletion" } }
+```
+
+---
+
+#### `POST /account/devices`  🔒
+
+Registers a new device key on the authenticated account and returns a PoP challenge. The device is not usable until verified via `/account/devices/verify`.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `device_public_key` | string | ✓ | 64-char hex Ed25519 public key |
+
+```json
+{ "device_public_key": "a4d1e2f3..." }
+```
+
+**Response `201`**
+
+```json
+{
+  "data": {
+    "challenge": {
+      "encrypted_nonce": "a1b2c3d4...",
+      "server_public_key": "e5f6a7b8..."
+    }
+  }
+}
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | Field absent |
+| 400 | `INVALID_DEVICE_KEY` | Not a 64-char hex string |
+| 409 | `KEY_EXISTS` | Device key already registered to any account |
+
+---
+
+#### `POST /account/devices/verify`  🔒
+
+Verifies a newly added device by solving its PoP challenge. Uses the same decryption procedure as `/auth/register/verify`. The device must belong to the authenticated account.
+
+**Request body**
+
+| Field | Type | Required |
+|-------|------|----------|
+| `device_public_key` | string | ✓ |
+| `nonce` | string | ✓ | 64-char hex decrypted nonce |
+
+**Response `200`**
+
+```json
+{ "data": { "ok": true } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | Any required field absent |
+| 404 | `NO_CHALLENGE` | No pending `device_add` challenge for this key |
+| 403 | `FORBIDDEN` | Challenge belongs to a different account |
+| 403 | `INVALID_NONCE` | Decrypted value does not match |
+
+---
+
+#### `DELETE /account/devices/{device_key}`  🔒
+
+Removes a device key from the account. The `{device_key}` path parameter is the 64-char hex public key.
+
+**Response `200`**
+
+```json
+{ "data": { "ok": true } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 404 | `NOT_FOUND` | Key not found on this account |
+
+---
+
+### Mailboxes
+
+A mailbox registers an account's interest in bundles for a given workspace. Bundles addressed to a device key whose account has a mailbox for that workspace are routed to that account.
+
+---
+
+#### `POST /mailboxes`  🔒
+
+Registers a mailbox for a workspace.
+
+**Request body**
+
+| Field | Type | Required |
+|-------|------|----------|
+| `workspace_id` | string | ✓ | Opaque client-defined workspace identifier |
+
+```json
+{ "workspace_id": "ws-7f3a9c2e" }
+```
+
+**Response `201`**
+
+```json
+{ "data": { "workspace_id": "ws-7f3a9c2e" } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | Field absent |
+
+---
+
+#### `DELETE /mailboxes/{workspace_id}`  🔒
+
+Removes a mailbox. Does not delete bundles already routed to the account.
+
+**Response `200`**
+
+```json
+{ "data": { "ok": true } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 404 | `NOT_FOUND` | Mailbox not found on this account |
+
+---
+
+#### `GET /mailboxes`  🔒
+
+Lists all mailboxes for the account.
+
+**Response `200`**
+
+```json
+{
+  "data": [
+    {
+      "workspace_id": "ws-7f3a9c2e",
+      "registered_at": "2026-02-01 08:00:00",
+      "pending_bundles": 3,
+      "storage_used": 524288
+    }
+  ]
+}
+```
+
+---
+
+### Bundles
+
+Bundles are end-to-end encrypted blobs routed from a sender device to one or more recipient devices. The relay never sees plaintext content.
+
+---
+
+#### `POST /bundles`  🔒
+
+Uploads a bundle and routes it to all specified recipient device keys that are registered in the relay. Recipients not found in the relay are silently skipped. The sender's own device key is always skipped even if included in `recipient_device_keys`.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `header` | string | ✓ | JSON-encoded routing header (see below) |
+| `payload` | string | ✓ | Base64-encoded encrypted bundle data |
+
+**Header JSON fields**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `workspace_id` | string | ✓ | Target workspace |
+| `sender_device_key` | string | ✓ | 64-char hex sender key |
+| `recipient_device_keys` | string[] | ✓ | Array of 64-char hex recipient keys |
+| `mode` | string | — | One of `delta` (default), `snapshot`, `invite`, `accept` |
+
+```json
+{
+  "header": "{\"workspace_id\":\"ws-7f3a9c2e\",\"sender_device_key\":\"d75a98...\",\"recipient_device_keys\":[\"a4d1e2...\"],\"mode\":\"delta\"}",
+  "payload": "base64encodedencrypteddata=="
+}
+```
+
+**Response `201`**
+
+```json
+{
+  "data": {
+    "routed_to": 1,
+    "bundle_ids": ["b8f3c2d1-..."]
+  }
+}
+```
+
+`routed_to` is the number of recipients a copy was created for. Recipients that exceed their storage quota are silently skipped.
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | `header` or `payload` absent |
+| 400 | `INVALID_PAYLOAD` | `payload` is not valid base64 |
+| 400 | `INVALID_HEADER` | Header JSON malformed or missing required fields |
+| 413 | `BUNDLE_TOO_LARGE` | Decoded payload exceeds 10 MB |
+
+---
+
+#### `GET /bundles`  🔒 ⏱
+
+Lists all bundles waiting for any verified device key on this account. Only metadata is returned; use `GET /bundles/{bundle_id}` to download the payload.
+
+This endpoint is **rate-limited**: at most one call per 60 seconds per account. Subsequent calls within the window return `429`.
+
+**Response `200`**
+
+```json
+{
+  "data": [
+    {
+      "bundle_id": "b8f3c2d1-...",
+      "workspace_id": "ws-7f3a9c2e",
+      "sender_device_key": "d75a98...",
+      "mode": "delta",
+      "size_bytes": 2048,
+      "created_at": "2026-03-01 12:00:00"
+    }
+  ]
+}
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 429 | `RATE_LIMITED` | Called again within 60 seconds; includes `retry_after` (seconds) field and `Retry-After` header |
+
+---
+
+#### `GET /bundles/{bundle_id}`  🔒
+
+Downloads a single bundle's payload. Only the recipient account may download it.
+
+**Response `200`**
+
+```json
+{
+  "data": {
+    "bundle_id": "b8f3c2d1-...",
+    "workspace_id": "ws-7f3a9c2e",
+    "sender_device_key": "d75a98...",
+    "mode": "delta",
+    "payload": "base64encodedencrypteddata=="
+  }
+}
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 404 | `NOT_FOUND` | Bundle not found or file missing |
+| 403 | `FORBIDDEN` | Bundle belongs to a different account |
+
+---
+
+#### `DELETE /bundles/{bundle_id}`  🔒
+
+Deletes a bundle after the client has processed it. Also decrements the recipient account's storage usage.
+
+**Response `200`**
+
+```json
+{ "data": { "ok": true } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 404 | `NOT_FOUND` | Bundle not found |
+| 403 | `FORBIDDEN` | Bundle belongs to a different account |
+
+---
+
+### Invites
+
+Invites allow an authenticated user to share an encrypted blob via a single public URL. The recipient does not need an account. The inviter creates an invite with an expiry; the relay holds the blob until fetched or expired.
+
+---
+
+#### `POST /invites`  🔒
+
+Uploads an encrypted invite blob and returns a shareable URL.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `payload` | string | ✓ | Base64-encoded encrypted invite blob |
+| `expires_at` | string | ✓ | ISO 8601 UTC datetime, e.g. `2026-06-01T00:00:00Z`; must be in the future and at most 90 days from now |
+
+```json
+{
+  "payload": "base64encodedencryptedblob==",
+  "expires_at": "2026-06-01T00:00:00Z"
+}
+```
+
+**Response `201`**
+
+```json
+{
+  "data": {
+    "invite_id": "9a3f1b2c-...",
+    "token": "1f177c2ee1861dc6...",
+    "url": "https://swarm.krillnotes.org/invites/1f177c2ee1861dc6...",
+    "expires_at": "2026-06-01T00:00:00Z"
+  }
+}
+```
+
+`token` is a 64-char hex string (256-bit random). The `url` is the public shareable link.
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 400 | `MISSING_FIELDS` | `payload` or `expires_at` absent |
+| 400 | `INVALID_PAYLOAD` | `payload` is not valid base64 |
+| 400 | `INVALID_EXPIRY` | `expires_at` is in the past, malformed, or more than 90 days away |
+| 413 | `PAYLOAD_TOO_LARGE` | Decoded payload exceeds 10 MB |
+
+---
+
+#### `GET /invites`  🔒
+
+Lists all invites created by the authenticated account.
+
+**Response `200`**
+
+```json
+{
+  "data": [
+    {
+      "invite_id": "9a3f1b2c-...",
+      "token": "1f177c2ee1861dc6...",
+      "url": "https://swarm.krillnotes.org/invites/1f177c2ee1861dc6...",
+      "expires_at": "2026-06-01 00:00:00",
+      "download_count": 2,
+      "created_at": "2026-03-14 09:00:00"
+    }
+  ]
+}
+```
+
+`download_count` counts only JSON fetches (app downloads), not browser page views.
+
+---
+
+#### `DELETE /invites/{token}`  🔒
+
+Revokes an invite immediately. Deletes the blob from storage. Only the owning account may revoke.
+
+**Response `200`**
+
+```json
+{ "data": { "ok": true } }
+```
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 404 | `NOT_FOUND` | Token not found |
+| 403 | `FORBIDDEN` | Invite belongs to a different account |
+
+---
+
+#### `GET /invites/{token}`
+
+Fetches an invite. **No authentication required.** The response format depends on the `Accept` header.
+
+**Content negotiation**
+
+| `Accept` contains | Response |
+|-------------------|----------|
+| `application/json` | JSON envelope with base64 payload |
+| anything else | HTML landing page for browsers |
+
+Only JSON fetches increment the `download_count`.
+
+**JSON response `200`** (`Accept: application/json`)
+
+```json
+{
+  "data": {
+    "payload": "base64encodedencryptedblob==",
+    "expires_at": "2026-06-01 00:00:00"
+  }
+}
+```
+
+**HTML response `200`**
+
+A minimal landing page instructing the recipient to open the URL in the KrillNotes app.
+
+**Errors**
+
+| Status | Code | Cause |
+|--------|------|-------|
+| 404 | `NOT_FOUND` | Token does not exist (JSON) or "no longer valid" page (HTML) |
+| 410 | `GONE` | Invite has expired (JSON) or "no longer valid" page (HTML) |
+
+---
+
+## Error reference
+
+All error responses use this shape:
+
+```json
+{ "error": { "code": "SNAKE_CASE", "message": "Human-readable string" } }
+```
+
+Some errors include additional fields:
+
+| Code | Extra fields |
+|------|-------------|
+| `RATE_LIMITED` | `retry_after` (int, seconds); also sets `Retry-After` response header |
+
+---
+
+## Limits
+
+| Setting | Default |
+|---------|---------|
+| Session lifetime | 30 days |
+| Challenge lifetime | 5 minutes |
+| Password reset token lifetime | 1 hour |
+| Max bundle / invite payload size | 10 MB |
+| Max storage per account | 100 MB |
+| Bundle retention | 30 days |
+| Invite max expiry | 90 days |
+| Account deletion grace period | 90 days |
+| Minimum bundle poll interval | 60 seconds |

--- a/docs/superpowers/plans/2026-03-15-cli-admin-tool.md
+++ b/docs/superpowers/plans/2026-03-15-cli-admin-tool.md
@@ -1,0 +1,1523 @@
+# CLI Admin Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a read-only CLI admin tool (`bin/admin.php`) that provides a full dashboard and per-section drill-downs into the relay database and storage.
+
+**Architecture:** Single PHP file following the same bootstrap pattern as `bin/cleanup.php` — require autoloader, load settings, create PDO via `Connection::create()`, run queries directly. Each section is a standalone function with `(PDO $pdo, array $settings, bool $detailed)` signature. A dispatch block routes `$argv[1]` to the appropriate function.
+
+**Tech Stack:** PHP 8.3, SQLite (PDO), PHPUnit for tests. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-03-15-cli-admin-tool-design.md`
+
+---
+
+## Chunk 1: Helper Functions + Dispatch Skeleton
+
+### Task 1: Write failing tests for helper functions
+
+**Files:**
+- Create: `tests/Unit/Cli/AdminHelpersTest.php`
+
+- [ ] **Step 1: Write the test file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PHPUnit\Framework\TestCase;
+
+// We'll require the admin.php file and test its functions directly.
+// The functions will be defined in the global namespace inside bin/admin.php.
+
+final class AdminHelpersTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // Load the admin functions (the file guards against double-include
+        // and skips dispatch when included from tests).
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+    }
+
+    // --- humanBytes ---
+
+    public function test_human_bytes_zero(): void
+    {
+        $this->assertSame('0 B', humanBytes(0));
+    }
+
+    public function test_human_bytes_bytes(): void
+    {
+        $this->assertSame('512 B', humanBytes(512));
+    }
+
+    public function test_human_bytes_kilobytes(): void
+    {
+        $this->assertSame('1.5 KB', humanBytes(1536));
+    }
+
+    public function test_human_bytes_megabytes(): void
+    {
+        $this->assertSame('10.0 MB', humanBytes(10 * 1024 * 1024));
+    }
+
+    public function test_human_bytes_gigabytes(): void
+    {
+        $this->assertSame('2.3 GB', humanBytes(2469606195));
+    }
+
+    // --- relativeTime ---
+
+    public function test_relative_time_null(): void
+    {
+        $this->assertSame('never', relativeTime(null));
+    }
+
+    public function test_relative_time_seconds_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-30 seconds'));
+        $this->assertSame('just now', relativeTime($ts));
+    }
+
+    public function test_relative_time_minutes_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-5 minutes'));
+        $this->assertSame('5m ago', relativeTime($ts));
+    }
+
+    public function test_relative_time_hours_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-3 hours'));
+        $this->assertSame('3h ago', relativeTime($ts));
+    }
+
+    public function test_relative_time_days_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-12 days'));
+        $this->assertSame('12d ago', relativeTime($ts));
+    }
+
+    // --- relativeTimeFuture ---
+
+    public function test_relative_time_future_minutes(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('+48 minutes'));
+        $this->assertSame('in 48m', relativeTimeFuture($ts));
+    }
+
+    public function test_relative_time_future_hours(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('+5 hours'));
+        $this->assertSame('in 5h', relativeTimeFuture($ts));
+    }
+
+    public function test_relative_time_future_days(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('+16 days'));
+        $this->assertSame('in 16d', relativeTimeFuture($ts));
+    }
+
+    public function test_relative_time_future_already_expired(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-2 days'));
+        $this->assertSame('expired 2d ago!', relativeTimeFuture($ts));
+    }
+
+    // --- progressBar ---
+
+    public function test_progress_bar_normal(): void
+    {
+        $result = progressBar(54 * 1024 * 1024, 100 * 1024 * 1024);
+        $this->assertSame('54.0 MB / 100.0 MB (54%)', $result);
+    }
+
+    public function test_progress_bar_zero(): void
+    {
+        $result = progressBar(0, 100 * 1024 * 1024);
+        $this->assertSame('0 B / 100.0 MB (0%)', $result);
+    }
+
+    public function test_progress_bar_overflow(): void
+    {
+        $current = 112 * 1024 * 1024;
+        $max = 100 * 1024 * 1024;
+        $result = progressBar($current, $max);
+        $this->assertSame('112.0 MB / 100.0 MB (112%)', $result);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminHelpersTest.php -v`
+Expected: FAIL — file not found / functions not defined.
+
+### Task 2: Create admin.php with helpers and dispatch skeleton
+
+**Files:**
+- Create: `bin/admin.php`
+
+- [ ] **Step 3: Write the admin.php file with helpers and dispatch**
+
+```php
+<?php
+
+/**
+ * CLI admin tool for inspecting the relay database and storage.
+ *
+ * Usage:
+ *   php bin/admin.php              Full dashboard
+ *   php bin/admin.php accounts     Account details
+ *   php bin/admin.php bundles      Bundle/workspace details
+ *   php bin/admin.php sessions     Session, challenge, and reset details
+ *   php bin/admin.php invites      Invite details
+ *   php bin/admin.php health       System health
+ *   php bin/admin.php help         Show this help
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Relay\Database\Connection;
+
+// ── Helper functions ────────────────────────────────────────────────
+
+function humanBytes(int $bytes): string
+{
+    if ($bytes === 0) {
+        return '0 B';
+    }
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $i = 0;
+    $value = (float) $bytes;
+    while ($value >= 1024 && $i < count($units) - 1) {
+        $value /= 1024;
+        $i++;
+    }
+    return $i === 0
+        ? "{$bytes} B"
+        : sprintf('%.1f %s', $value, $units[$i]);
+}
+
+function relativeTime(?string $timestamp): string
+{
+    if ($timestamp === null) {
+        return 'never';
+    }
+    $diff = time() - strtotime($timestamp);
+    if ($diff < 60) {
+        return 'just now';
+    }
+    if ($diff < 3600) {
+        return intdiv($diff, 60) . 'm ago';
+    }
+    if ($diff < 86400) {
+        return intdiv($diff, 3600) . 'h ago';
+    }
+    return intdiv($diff, 86400) . 'd ago';
+}
+
+function relativeTimeFuture(string $timestamp): string
+{
+    $diff = strtotime($timestamp) - time();
+    if ($diff < 0) {
+        $ago = abs($diff);
+        if ($ago < 3600) {
+            return 'expired ' . intdiv($ago, 60) . 'm ago!';
+        }
+        if ($ago < 86400) {
+            return 'expired ' . intdiv($ago, 3600) . 'h ago!';
+        }
+        return 'expired ' . intdiv($ago, 86400) . 'd ago!';
+    }
+    if ($diff < 3600) {
+        return 'in ' . intdiv($diff, 60) . 'm';
+    }
+    if ($diff < 86400) {
+        return 'in ' . intdiv($diff, 3600) . 'h';
+    }
+    return 'in ' . intdiv($diff, 86400) . 'd';
+}
+
+function progressBar(int $current, int $max): string
+{
+    $pct = $max > 0 ? (int) round($current / $max * 100) : 0;
+    return humanBytes($current) . ' / ' . humanBytes($max) . " ({$pct}%)";
+}
+
+// ── Table formatter ─────────────────────────────────────────────────
+
+function printTable(array $headers, array $rows): void
+{
+    if (empty($rows)) {
+        echo "  (none)\n";
+        return;
+    }
+
+    // Calculate column widths
+    $widths = [];
+    foreach ($headers as $i => $header) {
+        $widths[$i] = mb_strlen($header);
+    }
+    foreach ($rows as $row) {
+        foreach (array_values($row) as $i => $cell) {
+            $widths[$i] = max($widths[$i] ?? 0, mb_strlen((string) $cell));
+        }
+    }
+
+    // Print header
+    $line = '  ';
+    foreach ($headers as $i => $header) {
+        $line .= str_pad($header, $widths[$i] + 2);
+    }
+    echo $line . "\n";
+    echo '  ' . str_repeat('─', array_sum($widths) + count($widths) * 2) . "\n";
+
+    // Print rows
+    foreach ($rows as $row) {
+        $line = '  ';
+        foreach (array_values($row) as $i => $cell) {
+            $line .= str_pad((string) $cell, $widths[$i] + 2);
+        }
+        echo $line . "\n";
+    }
+}
+
+// ── Section stubs (to be implemented in subsequent tasks) ───────────
+// All functions MUST be defined before the PHPUNIT_RUNNING guard so
+// they are available when the file is loaded from tests.
+
+function showAccounts(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Accounts: (not yet implemented)\n";
+}
+
+function showBundles(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Bundles: (not yet implemented)\n";
+}
+
+function showSessions(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Sessions: (not yet implemented)\n";
+}
+
+function showInvites(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Invites: (not yet implemented)\n";
+}
+
+function showHealth(\PDO $pdo, array $settings, bool $detailed): void
+{
+    echo "Health: (not yet implemented)\n";
+}
+
+function showHelp(): void
+{
+    echo <<<HELP
+    swarm-relay admin tool
+
+    Usage: php bin/admin.php [command]
+
+    Commands:
+      (none)     Full dashboard (all sections)
+      accounts   Account details
+      bundles    Bundle/workspace details
+      sessions   Session, challenge, and reset details
+      invites    Invite details
+      health     System health — DB, storage, migrations, settings
+      help       Show this help
+
+    HELP;
+}
+
+// ── Guard: skip dispatch when loaded from tests ─────────────────────
+
+if (defined('PHPUNIT_RUNNING')) {
+    return;
+}
+
+// ── Bootstrap ───────────────────────────────────────────────────────
+
+$settings = require __DIR__ . '/../config/settings.php';
+$pdo = Connection::create($settings['database']['path']);
+
+// ── Dispatch ────────────────────────────────────────────────────────
+
+$command = $argv[1] ?? 'dashboard';
+
+switch ($command) {
+    case 'dashboard':
+        showAccounts($pdo, $settings, false);
+        showBundles($pdo, $settings, false);
+        showSessions($pdo, $settings, false);
+        showInvites($pdo, $settings, false);
+        showHealth($pdo, $settings, false);
+        break;
+    case 'accounts':
+        showAccounts($pdo, $settings, true);
+        break;
+    case 'bundles':
+        showBundles($pdo, $settings, true);
+        break;
+    case 'sessions':
+        showSessions($pdo, $settings, true);
+        break;
+    case 'invites':
+        showInvites($pdo, $settings, true);
+        break;
+    case 'health':
+        showHealth($pdo, $settings, true);
+        break;
+    case 'help':
+        showHelp();
+        break;
+    default:
+        echo "Unknown command: {$command}\n\n";
+        showHelp();
+        exit(1);
+}
+```
+
+- [ ] **Step 4: Add PHPUNIT_RUNNING constant to test bootstrap**
+
+In `tests/bootstrap.php`, add the constant so `admin.php` skips dispatch when loaded in tests:
+
+```php
+// Add before the require line:
+define('PHPUNIT_RUNNING', true);
+```
+
+File: `tests/bootstrap.php` — modify.
+
+- [ ] **Step 5: Run helper tests to verify they pass**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminHelpersTest.php -v`
+Expected: All 14 tests PASS.
+
+- [ ] **Step 6: Run full test suite to confirm no regressions**
+
+Run: `php vendor/bin/phpunit -v`
+Expected: All existing tests still PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bin/admin.php tests/Unit/Cli/AdminHelpersTest.php tests/bootstrap.php
+git commit -m "feat: admin CLI skeleton with helpers and dispatch
+
+Includes PHPUNIT_RUNNING guard in bootstrap.php so admin.php
+skips DB bootstrap when loaded from tests."
+```
+
+---
+
+## Chunk 2: showAccounts
+
+### Task 3: Write failing tests for showAccounts
+
+**Files:**
+- Create: `tests/Unit/Cli/AdminAccountsTest.php`
+
+- [ ] **Step 1: Write the test file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\DeviceKeyRepository;
+
+final class AdminAccountsTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_accounts_dashboard_with_no_accounts(): void
+    {
+        ob_start();
+        showAccounts($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Accounts:', $output);
+        $this->assertStringContainsString('0 total', $output);
+    }
+
+    public function test_accounts_dashboard_with_data(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $repo->create('alice@example.com', 'hash', 'uuid1');
+        $repo->create('bob@example.com', 'hash', 'uuid2');
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('2 total', $output);
+    }
+
+    public function test_accounts_detail_shows_emails(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $repo->create('alice@example.com', 'hash', 'uuid1');
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('alice@example.com', $output);
+    }
+
+    public function test_accounts_detail_shows_device_counts(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $id = $repo->create('alice@example.com', 'hash', 'uuid1');
+
+        $dk = new DeviceKeyRepository($this->pdo);
+        $dk->add($id, 'pubkey1');
+        $dk->add($id, 'pubkey2');
+        $dk->markVerified('pubkey1');
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('2 (1 verified)', $output);
+    }
+
+    public function test_accounts_detail_shows_flagged(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $id = $repo->create('alice@example.com', 'hash', 'uuid1');
+        $repo->flagForDeletion($id);
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('yes', $output);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminAccountsTest.php -v`
+Expected: FAIL — output says "(not yet implemented)".
+
+### Task 4: Implement showAccounts
+
+**Files:**
+- Modify: `bin/admin.php` — replace the `showAccounts` stub (before the guard).
+
+- [ ] **Step 3: Replace the showAccounts stub**
+
+```php
+function showAccounts(\PDO $pdo, array $settings, bool $detailed): void
+{
+    $maxStorage = $settings['limits']['max_storage_per_account_bytes'];
+
+    // Summary stats
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            SUM(CASE WHEN flagged_for_deletion IS NOT NULL THEN 1 ELSE 0 END) as flagged,
+            SUM(storage_used) as total_storage
+         FROM accounts"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $flagged = (int) $stats['flagged'];
+    $totalStorage = (int) $stats['total_storage'];
+
+    echo "Accounts: {$total} total, {$flagged} flagged for deletion, "
+        . humanBytes($totalStorage) . " total storage used\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Detail table
+    $rows = $pdo->query(
+        "SELECT
+            a.email,
+            a.storage_used,
+            a.flagged_for_deletion,
+            a.created_at,
+            a.last_poll_at,
+            COUNT(dk.id) as device_total,
+            SUM(CASE WHEN dk.verified = 1 THEN 1 ELSE 0 END) as device_verified
+         FROM accounts a
+         LEFT JOIN device_keys dk ON dk.account_id = a.account_id
+         GROUP BY a.account_id
+         ORDER BY a.created_at DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        $flaggedStr = $row['flagged_for_deletion']
+            ? 'yes (' . relativeTime($row['flagged_for_deletion']) . ')'
+            : '—';
+
+        $tableRows[] = [
+            'email'    => $row['email'],
+            'devices'  => $row['device_total'] . ' (' . (int) $row['device_verified'] . ' verified)',
+            'storage'  => progressBar((int) $row['storage_used'], $maxStorage),
+            'flagged'  => $flaggedStr,
+            'created'  => relativeTime($row['created_at']),
+            'lastPoll' => relativeTime($row['last_poll_at']),
+        ];
+    }
+
+    echo "\n";
+    printTable(['Email', 'Devices', 'Storage', 'Flagged', 'Created', 'Last Poll'], $tableRows);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminAccountsTest.php -v`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/admin.php tests/Unit/Cli/AdminAccountsTest.php
+git commit -m "feat: implement showAccounts section in admin CLI"
+```
+
+---
+
+## Chunk 3: showBundles
+
+### Task 5: Write failing tests for showBundles
+
+**Files:**
+- Create: `tests/Unit/Cli/AdminBundlesTest.php`
+
+- [ ] **Step 1: Write the test file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\DeviceKeyRepository;
+use Relay\Repository\MailboxRepository;
+use Relay\Repository\BundleRepository;
+
+final class AdminBundlesTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_bundles_dashboard_empty(): void
+    {
+        ob_start();
+        showBundles($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Bundles:', $output);
+        $this->assertStringContainsString('0 pending', $output);
+    }
+
+    public function test_bundles_dashboard_with_data(): void
+    {
+        $this->seedBundle('ws-1', 'sender-key', 'recipient-key', 'delta', 1024);
+
+        ob_start();
+        showBundles($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('1 pending', $output);
+    }
+
+    public function test_bundles_detail_shows_workspace(): void
+    {
+        $this->seedBundleWithMailbox(
+            'workspace-abc123def456',
+            'alice@example.com',
+            'delta',
+            2048
+        );
+
+        ob_start();
+        showBundles($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('workspac...', $output);
+        $this->assertStringContainsString('alice@example.com', $output);
+        $this->assertStringContainsString('1 delta', $output);
+    }
+
+    public function test_bundles_detail_unknown_first_member(): void
+    {
+        // Bundle exists but no mailbox for the workspace
+        $this->seedBundle('orphan-ws', 'sender', 'recipient', 'snapshot', 512);
+
+        ob_start();
+        showBundles($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('(unknown)', $output);
+    }
+
+    private function seedBundle(
+        string $workspaceId,
+        string $senderKey,
+        string $recipientKey,
+        string $mode,
+        int $size
+    ): void {
+        $bundleRepo = new BundleRepository($this->pdo);
+        $bundleId = bin2hex(random_bytes(16));
+        $bundleRepo->createWithId(
+            $bundleId,
+            $workspaceId,
+            $senderKey,
+            $recipientKey,
+            $mode,
+            $size,
+            "bundles/ab/{$bundleId}.swarm"
+        );
+    }
+
+    private function seedBundleWithMailbox(
+        string $workspaceId,
+        string $email,
+        string $mode,
+        int $size
+    ): void {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create($email, 'hash', 'uuid-' . bin2hex(random_bytes(4)));
+
+        $dk = new DeviceKeyRepository($this->pdo);
+        $pubkey = 'dk-' . bin2hex(random_bytes(8));
+        $dk->add($accountId, $pubkey);
+        $dk->markVerified($pubkey);
+
+        $mailboxRepo = new MailboxRepository($this->pdo);
+        $mailboxRepo->create($accountId, $workspaceId);
+
+        $this->seedBundle($workspaceId, $pubkey, $pubkey, $mode, $size);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminBundlesTest.php -v`
+Expected: FAIL — output says "(not yet implemented)".
+
+### Task 6: Implement showBundles
+
+**Files:**
+- Modify: `bin/admin.php` — replace the `showBundles` stub (before the guard).
+
+- [ ] **Step 3: Replace the showBundles stub**
+
+```php
+function showBundles(\PDO $pdo, array $settings, bool $detailed): void
+{
+    $retentionDays = $settings['limits']['bundle_retention_days'];
+
+    // Summary stats
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            COALESCE(SUM(size_bytes), 0) as total_size,
+            MIN(created_at) as oldest_created
+         FROM bundles"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $totalSize = (int) $stats['total_size'];
+    $oldestCreated = $stats['oldest_created'];
+
+    $oldestStr = '';
+    if ($oldestCreated) {
+        $oldestStr = ', oldest: ' . relativeTime($oldestCreated);
+        // Compute expiry of oldest bundle
+        $expiresAt = date('Y-m-d H:i:s', strtotime($oldestCreated) + $retentionDays * 86400);
+        $oldestStr .= ' (' . relativeTimeFuture($expiresAt) . ')';
+    }
+
+    echo "Bundles: " . number_format($total) . " pending, "
+        . humanBytes($totalSize) . " on disk{$oldestStr}\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Per-workspace detail with first member lookup
+    $rows = $pdo->query(
+        "SELECT
+            b.workspace_id,
+            COUNT(*) as bundle_count,
+            SUM(b.size_bytes) as total_size,
+            MIN(b.created_at) as oldest,
+            MAX(b.created_at) as newest,
+            GROUP_CONCAT(b.mode) as modes
+         FROM bundles b
+         GROUP BY b.workspace_id
+         ORDER BY bundle_count DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        // Find first member
+        $member = $pdo->prepare(
+            "SELECT a.email
+             FROM mailboxes m
+             JOIN accounts a ON a.account_id = m.account_id
+             WHERE m.workspace_id = ?
+             ORDER BY m.registered_at ASC
+             LIMIT 1"
+        );
+        $member->execute([$row['workspace_id']]);
+        $firstMember = $member->fetchColumn() ?: '(unknown)';
+
+        // Mode breakdown
+        $modeList = explode(',', $row['modes']);
+        $modeCounts = array_count_values($modeList);
+        $modeStr = implode(', ', array_map(
+            fn($count, $mode) => "{$count} {$mode}",
+            $modeCounts,
+            array_keys($modeCounts)
+        ));
+
+        // Truncate workspace ID
+        $wsDisplay = strlen($row['workspace_id']) > 11
+            ? substr($row['workspace_id'], 0, 8) . '...'
+            : $row['workspace_id'];
+
+        $tableRows[] = [
+            'workspace'   => $wsDisplay,
+            'firstMember' => $firstMember,
+            'bundles'     => (string) $row['bundle_count'],
+            'size'        => humanBytes((int) $row['total_size']),
+            'oldest'      => relativeTime($row['oldest']),
+            'newest'      => relativeTime($row['newest']),
+            'modes'       => $modeStr,
+        ];
+    }
+
+    echo "\n";
+    printTable(
+        ['Workspace', 'First Member', 'Bundles', 'Size', 'Oldest', 'Newest', 'Modes'],
+        $tableRows
+    );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminBundlesTest.php -v`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/admin.php tests/Unit/Cli/AdminBundlesTest.php
+git commit -m "feat: implement showBundles section in admin CLI"
+```
+
+---
+
+## Chunk 4: showSessions
+
+### Task 7: Write failing tests for showSessions
+
+**Files:**
+- Create: `tests/Unit/Cli/AdminSessionsTest.php`
+
+- [ ] **Step 1: Write the test file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\SessionRepository;
+use Relay\Repository\ChallengeRepository;
+
+final class AdminSessionsTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_sessions_dashboard_empty(): void
+    {
+        ob_start();
+        showSessions($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Sessions:', $output);
+        $this->assertStringContainsString('0 active', $output);
+    }
+
+    public function test_sessions_dashboard_with_data(): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create('alice@test.com', 'hash', 'uuid');
+
+        $sessionRepo = new SessionRepository($this->pdo);
+        $sessionRepo->create($accountId, 86400 * 30);
+
+        ob_start();
+        showSessions($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('1 active', $output);
+        $this->assertStringContainsString('1 accounts with active sessions', $output);
+    }
+
+    public function test_sessions_detail_shows_account(): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create('alice@test.com', 'hash', 'uuid');
+
+        $sessionRepo = new SessionRepository($this->pdo);
+        $sessionRepo->create($accountId, 86400 * 30);
+
+        ob_start();
+        showSessions($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('alice@test.com', $output);
+    }
+
+    public function test_sessions_shows_challenge_summary(): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create('alice@test.com', 'hash', 'uuid');
+
+        $challengeRepo = new ChallengeRepository($this->pdo);
+        $challengeRepo->create($accountId, 'pubkey', 'nonce', 'serverpub', 'registration', 300);
+
+        ob_start();
+        showSessions($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Challenges:', $output);
+        $this->assertStringContainsString('1 pending', $output);
+        $this->assertStringContainsString('registration', $output);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminSessionsTest.php -v`
+Expected: FAIL — output says "(not yet implemented)".
+
+### Task 8: Implement showSessions
+
+**Files:**
+- Modify: `bin/admin.php` — replace the `showSessions` stub (before the guard).
+
+- [ ] **Step 3: Replace the showSessions stub**
+
+```php
+function showSessions(\PDO $pdo, array $settings, bool $detailed): void
+{
+    // Summary stats
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            MIN(created_at) as oldest,
+            MIN(expires_at) as soonest_expiry,
+            COUNT(DISTINCT account_id) as account_count
+         FROM sessions
+         WHERE expires_at > datetime('now')"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $accountCount = (int) $stats['account_count'];
+
+    $oldestStr = '';
+    if ($stats['oldest']) {
+        $oldestStr = ', oldest: ' . relativeTime($stats['oldest'])
+            . ' (' . relativeTimeFuture($stats['soonest_expiry']) . ')';
+    }
+
+    echo "Sessions: {$total} active{$oldestStr}, {$accountCount} accounts with active sessions\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Per-account detail
+    $rows = $pdo->query(
+        "SELECT
+            a.email,
+            COUNT(s.token) as session_count,
+            MAX(s.created_at) as newest,
+            MIN(s.created_at) as oldest,
+            MIN(s.expires_at) as soonest_expiry
+         FROM sessions s
+         JOIN accounts a ON a.account_id = s.account_id
+         WHERE s.expires_at > datetime('now')
+         GROUP BY s.account_id
+         ORDER BY session_count DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        $tableRows[] = [
+            'account'  => $row['email'],
+            'sessions' => (string) $row['session_count'],
+            'newest'   => relativeTime($row['newest']),
+            'oldest'   => relativeTime($row['oldest']),
+            'expires'  => relativeTimeFuture($row['soonest_expiry']),
+        ];
+    }
+
+    echo "\n";
+    printTable(['Account', 'Sessions', 'Newest', 'Oldest', 'Expires'], $tableRows);
+
+    // Challenge summary
+    $challenges = $pdo->query(
+        "SELECT context, COUNT(*) as cnt, MIN(created_at) as oldest
+         FROM challenges
+         WHERE expires_at > datetime('now')
+         GROUP BY context"
+    )->fetchAll();
+
+    $totalChallenges = array_sum(array_column($challenges, 'cnt'));
+    if ($totalChallenges > 0) {
+        $parts = array_map(fn($c) => "{$c['cnt']} {$c['context']}", $challenges);
+        $oldest = min(array_column($challenges, 'oldest'));
+        echo "\nChallenges: {$totalChallenges} pending (" . implode(', ', $parts)
+            . '), oldest: ' . relativeTime($oldest) . "\n";
+    } else {
+        echo "\nChallenges: 0 pending\n";
+    }
+
+    // Password reset summary
+    $resets = $pdo->query(
+        "SELECT COUNT(*) as cnt, MIN(expires_at) as soonest
+         FROM password_resets
+         WHERE used = 0 AND expires_at > datetime('now')"
+    )->fetch();
+
+    $resetCount = (int) $resets['cnt'];
+    if ($resetCount > 0) {
+        echo "Password resets: {$resetCount} unused, expires "
+            . relativeTimeFuture($resets['soonest']) . "\n";
+    } else {
+        echo "Password resets: 0 unused\n";
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminSessionsTest.php -v`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/admin.php tests/Unit/Cli/AdminSessionsTest.php
+git commit -m "feat: implement showSessions section in admin CLI"
+```
+
+---
+
+## Chunk 5: showInvites
+
+### Task 9: Write failing tests for showInvites
+
+**Files:**
+- Create: `tests/Unit/Cli/AdminInvitesTest.php`
+
+- [ ] **Step 1: Write the test file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\InviteRepository;
+
+final class AdminInvitesTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_invites_dashboard_empty(): void
+    {
+        ob_start();
+        showInvites($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Invites:', $output);
+        $this->assertStringContainsString('0 active', $output);
+    }
+
+    public function test_invites_dashboard_with_data(): void
+    {
+        $this->seedInvite('alice@test.com', 2048, 5);
+
+        ob_start();
+        showInvites($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('1 active', $output);
+        $this->assertStringContainsString('5 total downloads', $output);
+    }
+
+    public function test_invites_detail_shows_token_and_account(): void
+    {
+        $this->seedInvite('alice@test.com', 1024, 0);
+
+        ob_start();
+        showInvites($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('alice@test.com', $output);
+        // Token should be truncated
+        $this->assertStringContainsString('...', $output);
+    }
+
+    private function seedInvite(string $email, int $size, int $downloads): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create($email, 'hash', 'uuid-' . bin2hex(random_bytes(4)));
+
+        $inviteRepo = new InviteRepository($this->pdo);
+        $inviteId = bin2hex(random_bytes(16));
+        $token = bin2hex(random_bytes(32));
+        $expiresAt = date('Y-m-d H:i:s', strtotime('+7 days'));
+        $inviteRepo->create($inviteId, $token, $accountId, "invites/ab/{$inviteId}.swarm", $size, $expiresAt);
+
+        // Simulate downloads
+        for ($i = 0; $i < $downloads; $i++) {
+            $inviteRepo->incrementDownloadCount($token);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminInvitesTest.php -v`
+Expected: FAIL — output says "(not yet implemented)".
+
+### Task 10: Implement showInvites
+
+**Files:**
+- Modify: `bin/admin.php` — replace the `showInvites` stub (before the guard).
+
+- [ ] **Step 3: Replace the showInvites stub**
+
+```php
+function showInvites(\PDO $pdo, array $settings, bool $detailed): void
+{
+    // Summary stats (only non-expired invites)
+    $stats = $pdo->query(
+        "SELECT
+            COUNT(*) as total,
+            COALESCE(SUM(size_bytes), 0) as total_size,
+            COALESCE(SUM(download_count), 0) as total_downloads
+         FROM invites
+         WHERE expires_at > datetime('now')"
+    )->fetch();
+
+    $total = (int) $stats['total'];
+    $totalSize = (int) $stats['total_size'];
+    $totalDownloads = (int) $stats['total_downloads'];
+
+    echo "Invites: {$total} active, " . humanBytes($totalSize)
+        . " on disk, {$totalDownloads} total downloads\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Detail table
+    $rows = $pdo->query(
+        "SELECT
+            i.token,
+            a.email,
+            i.size_bytes,
+            i.download_count,
+            i.created_at,
+            i.expires_at
+         FROM invites i
+         JOIN accounts a ON a.account_id = i.account_id
+         WHERE i.expires_at > datetime('now')
+         ORDER BY i.created_at DESC"
+    )->fetchAll();
+
+    $tableRows = [];
+    foreach ($rows as $row) {
+        $tokenDisplay = strlen($row['token']) > 11
+            ? substr($row['token'], 0, 8) . '...'
+            : $row['token'];
+
+        $tableRows[] = [
+            'token'     => $tokenDisplay,
+            'account'   => $row['email'],
+            'size'      => humanBytes((int) $row['size_bytes']),
+            'downloads' => (string) $row['download_count'],
+            'created'   => relativeTime($row['created_at']),
+            'expires'   => relativeTimeFuture($row['expires_at']),
+        ];
+    }
+
+    echo "\n";
+    printTable(['Token', 'Account', 'Size', 'Downloads', 'Created', 'Expires'], $tableRows);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminInvitesTest.php -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/admin.php tests/Unit/Cli/AdminInvitesTest.php
+git commit -m "feat: implement showInvites section in admin CLI"
+```
+
+---
+
+## Chunk 6: showHealth
+
+### Task 11: Write failing tests for showHealth
+
+**Files:**
+- Create: `tests/Unit/Cli/AdminHealthTest.php`
+
+- [ ] **Step 1: Write the test file**
+
+Note: Health checks filesystem and pragmas. For `:memory:` DBs some checks
+differ (no file size, journal mode returns `memory`). We test what we can and
+accept that the pragma values in `:memory:` differ from on-disk SQLite.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+
+final class AdminHealthTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_health_dashboard(): void
+    {
+        ob_start();
+        showHealth($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Health:', $output);
+        $this->assertStringContainsString('migrations applied', $output);
+    }
+
+    public function test_health_detail_shows_settings(): void
+    {
+        ob_start();
+        showHealth($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('=== SETTINGS ===', $output);
+        $this->assertStringContainsString('Bundle retention:', $output);
+        $this->assertStringContainsString('30 days', $output);
+        $this->assertStringContainsString('Max storage/account:', $output);
+        $this->assertStringContainsString('100.0 MB', $output);
+    }
+
+    public function test_health_detail_shows_migrations(): void
+    {
+        ob_start();
+        showHealth($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('=== DATABASE ===', $output);
+        $this->assertStringContainsString('Migrations:', $output);
+        // All 8 migrations should be applied
+        $this->assertStringContainsString('8/8 applied', $output);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminHealthTest.php -v`
+Expected: FAIL — output says "(not yet implemented)".
+
+### Task 12: Implement showHealth
+
+**Files:**
+- Modify: `bin/admin.php` — replace the `showHealth` stub (before the guard).
+  Also add `dirSize()` and `dirFileCount()` helper functions next to it.
+
+- [ ] **Step 3: Replace the showHealth stub and add dir helpers**
+
+```php
+function showHealth(\PDO $pdo, array $settings, bool $detailed): void
+{
+    $migrationsPath = dirname(__DIR__) . '/migrations';
+    $dbPath = $settings['database']['path'];
+    $bundlesPath = $settings['storage']['bundles_path'];
+    $invitesPath = $settings['storage']['invites_path'];
+
+    // Migration count
+    $migrationFiles = glob($migrationsPath . '/*.sql');
+    $totalMigrations = count($migrationFiles);
+    $appliedMigrations = (int) $pdo->query('SELECT COUNT(*) FROM _migrations')->fetchColumn();
+
+    $migrationStr = "{$appliedMigrations}/{$totalMigrations} applied";
+    if ($appliedMigrations < $totalMigrations) {
+        $pending = $totalMigrations - $appliedMigrations;
+        $migrationStr .= " ⚠ {$pending} pending";
+    }
+
+    // Pragma checks
+    $journalMode = $pdo->query('PRAGMA journal_mode')->fetchColumn();
+    $foreignKeys = $pdo->query('PRAGMA foreign_keys')->fetchColumn();
+
+    // File sizes
+    $dbSize = file_exists($dbPath) ? filesize($dbPath) : 0;
+    $bundlesDiskSize = dirSize($bundlesPath);
+    $bundlesFileCount = dirFileCount($bundlesPath);
+    $invitesDiskSize = dirSize($invitesPath);
+    $invitesFileCount = dirFileCount($invitesPath);
+
+    // Dashboard line
+    $journalOk = strtolower($journalMode) === 'wal' ? 'WAL ok' : "journal: {$journalMode}";
+    echo "Health: DB " . humanBytes($dbSize) . ", blobs " . humanBytes($bundlesDiskSize)
+        . ", invites " . humanBytes($invitesDiskSize)
+        . ", {$migrationStr}, {$journalOk}\n";
+
+    if (!$detailed) {
+        return;
+    }
+
+    // Detail view
+    $journalCheck = strtolower($journalMode) === 'wal' ? 'WAL ✓' : "{$journalMode} ⚠";
+    $fkCheck = $foreignKeys ? 'ON ✓' : 'OFF ⚠';
+
+    echo "\n=== DATABASE ===\n";
+    echo "  File:          " . (file_exists($dbPath) ? "{$dbPath} (" . humanBytes($dbSize) . ")" : '(in-memory)') . "\n";
+    echo "  Journal:       {$journalCheck}\n";
+    echo "  Foreign keys:  {$fkCheck}\n";
+    echo "  Migrations:    {$migrationStr}\n";
+
+    echo "\n=== STORAGE ===\n";
+    echo "  Bundles dir:   " . humanBytes($bundlesDiskSize) . " ({$bundlesFileCount} files)\n";
+    echo "  Invites dir:   " . humanBytes($invitesDiskSize) . " ({$invitesFileCount} files)\n";
+    echo "  Total disk:    " . humanBytes($bundlesDiskSize + $invitesDiskSize) . "\n";
+
+    echo "\n=== SETTINGS ===\n";
+    echo "  Bundle retention:     {$settings['limits']['bundle_retention_days']} days\n";
+    echo "  Session lifetime:     " . intdiv($settings['auth']['session_lifetime_seconds'], 86400) . " days\n";
+    echo "  Challenge lifetime:   " . intdiv($settings['auth']['challenge_lifetime_seconds'], 60) . " minutes\n";
+    echo "  Reset token lifetime: " . intdiv($settings['auth']['reset_token_lifetime_seconds'], 3600) . " hour(s)\n";
+    echo "  Max bundle size:      " . humanBytes($settings['limits']['max_bundle_size_bytes']) . "\n";
+    echo "  Max storage/account:  " . humanBytes($settings['limits']['max_storage_per_account_bytes']) . "\n";
+    echo "  Deletion grace:       {$settings['limits']['account_deletion_grace_days']} days\n";
+    echo "  Min poll interval:    {$settings['limits']['min_poll_interval_seconds']} seconds\n";
+}
+
+function dirSize(string $path): int
+{
+    if (!is_dir($path)) {
+        return 0;
+    }
+    $size = 0;
+    foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $file) {
+        $size += $file->getSize();
+    }
+    return $size;
+}
+
+function dirFileCount(string $path): int
+{
+    if (!is_dir($path)) {
+        return 0;
+    }
+    $count = 0;
+    foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $file) {
+        if ($file->isFile()) {
+            $count++;
+        }
+    }
+    return $count;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `php vendor/bin/phpunit tests/Unit/Cli/AdminHealthTest.php -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/admin.php tests/Unit/Cli/AdminHealthTest.php
+git commit -m "feat: implement showHealth section in admin CLI"
+```
+
+---
+
+## Chunk 7: Final Integration + Docs
+
+### Task 13: Run full test suite
+
+- [ ] **Step 1: Run all tests**
+
+Run: `php vendor/bin/phpunit -v`
+Expected: All tests PASS (existing + new admin tests).
+
+### Task 14: Manual smoke test
+
+- [ ] **Step 2: Run admin dashboard against live DB**
+
+Run: `php bin/admin.php`
+Expected: Prints all 5 section summary lines. Verify formatting looks right.
+
+- [ ] **Step 3: Run each subcommand**
+
+Run each of:
+```bash
+php bin/admin.php accounts
+php bin/admin.php bundles
+php bin/admin.php sessions
+php bin/admin.php invites
+php bin/admin.php health
+php bin/admin.php help
+php bin/admin.php nonsense
+```
+
+Expected:
+- Each prints its summary + detail table.
+- `help` prints usage text.
+- `nonsense` prints error + usage text and exits with code 1.
+
+### Task 15: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 4: Add admin CLI to key commands section**
+
+In the `## Key commands` section, add:
+
+```bash
+# Admin dashboard (read-only DB inspection)
+php bin/admin.php              # Full dashboard
+php bin/admin.php accounts     # Account details
+php bin/admin.php bundles      # Bundle/workspace details
+php bin/admin.php sessions     # Session/challenge/reset details
+php bin/admin.php invites      # Invite details
+php bin/admin.php health       # System health + settings
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add admin CLI to CLAUDE.md key commands"
+```
+
+### Task 16: Final full test suite run
+
+- [ ] **Step 6: Run all tests one final time**
+
+Run: `php vendor/bin/phpunit -v`
+Expected: All tests PASS.

--- a/docs/superpowers/specs/2026-03-15-cli-admin-tool-design.md
+++ b/docs/superpowers/specs/2026-03-15-cli-admin-tool-design.md
@@ -52,7 +52,9 @@ line plus detail table).
 
 - `humanBytes($bytes)` — e.g. `4.2 MB`, `256 KB`
 - `relativeTime($timestamp)` — e.g. `3h ago`, `12d ago`, `never`
-- `progressBar($current, $max)` — e.g. `54.2 MB / 100 MB (54%)`
+- `progressBar($current, $max)` — e.g. `54.2 MB / 100 MB (54%)`. When
+  `$current > $max` (e.g. stale `storage_used`), renders as-is without clamping:
+  `112.3 MB / 100 MB (112%)`.
 
 ## Section Details
 
@@ -120,9 +122,10 @@ Sessions: 18 active, oldest: 28d ago (expires in 2d), 3 accounts with active ses
 | alice@example.com | 3 | 1h ago | 14d ago | in 16d |
 | bob@example.com | 1 | 5d ago | 5d ago | in 25d |
 
-- Expires computed directly from `sessions.expires_at` (not derived from
+- Expires shows the soonest-expiring session per account (`MIN(expires_at)`),
+  computed directly from `sessions.expires_at` (not derived from
   `session_lifetime_seconds`, since the setting only applies at creation time).
-  Flags sessions expiring within 24h.
+  Flags when the soonest session expires within 24h.
 - Followed by challenge and password-reset summaries:
 
 ```

--- a/docs/superpowers/specs/2026-03-15-cli-admin-tool-design.md
+++ b/docs/superpowers/specs/2026-03-15-cli-admin-tool-design.md
@@ -1,0 +1,192 @@
+# CLI Admin Tool — Design Spec
+
+## Overview
+
+A read-only CLI tool (`bin/admin.php`) for inspecting the relay database and
+storage. Provides a full dashboard view and per-section drill-downs. Designed so
+write/action subcommands can be added later.
+
+## Approach
+
+Single file, same bootstrap pattern as `install.php` and `cleanup.php` — direct
+repo instantiation, no DI container, no new dependencies.
+
+## Commands
+
+| Command                      | Behaviour                                      |
+|------------------------------|-------------------------------------------------|
+| `php bin/admin.php`          | Full dashboard (compact summary of all sections) |
+| `php bin/admin.php accounts` | Account detail table                            |
+| `php bin/admin.php bundles`  | Bundle/workspace detail table                   |
+| `php bin/admin.php sessions` | Session, challenge, and reset detail             |
+| `php bin/admin.php invites`  | Invite detail table                             |
+| `php bin/admin.php health`   | System health — DB, storage, migrations, pragmas |
+| `php bin/admin.php help`     | Usage text                                      |
+
+Unknown commands print an error plus the help text.
+
+## Dispatch
+
+```php
+$command = $argv[1] ?? 'dashboard';
+```
+
+Each section is a standalone function: `showAccounts($pdo, $settings)`, etc.
+The `dashboard` command calls all section functions, which detect dashboard vs
+detail mode via a parameter (or by checking whether they were called directly).
+
+## Output Format Conventions
+
+- **Sizes**: human-readable with limit context — `54.2 MB / 100 MB (54%)` when
+  a setting limit applies, plain `54.2 MB` otherwise.
+- **Times**: relative — `3h ago`, `12d ago`, `never` — with absolute date in
+  parentheses where useful (e.g. `12d ago (2026-03-03)`).
+- **Counts**: plain numbers, with limit context where applicable.
+- **Section headers**: `=== ACCOUNTS ===` style separators.
+- **Dashboard mode**: compact summary line per section.
+- **Detail mode**: summary line plus a formatted table.
+
+### Helper functions (defined once in the file)
+
+- `humanBytes($bytes)` — e.g. `4.2 MB`, `256 KB`
+- `relativeTime($timestamp)` — e.g. `3h ago`, `12d ago`, `never`
+- `progressBar($current, $max)` — e.g. `54.2 MB / 100 MB (54%)`
+
+## Section Details
+
+### Accounts
+
+**Dashboard line:**
+```
+Accounts: 42 total, 3 flagged for deletion, 1.2 GB total storage used
+```
+
+**Detail table:**
+
+| Email | Devices | Storage | Flagged | Created | Last Poll |
+|---|---|---|---|---|---|
+| alice@example.com | 2 (2 verified) | 54.2 MB / 100 MB (54%) | — | 30d ago | 2h ago |
+| bob@example.com | 1 (0 verified) | 0 B / 100 MB (0%) | yes (12d ago) | 45d ago | never |
+
+- Storage compared against `max_storage_per_account_bytes`.
+- Device counts from JOIN on `device_keys` (total + verified).
+- Flagged shows time since flagging (relevant to `account_deletion_grace_days`).
+- Last Poll from `last_poll_at`; `never` if null.
+- Sorted by `created_at` descending.
+
+### Bundles
+
+**Dashboard line:**
+```
+Bundles: 1,847 pending, 892.4 MB on disk, oldest: 28d ago (expires in 2d)
+```
+
+**Detail table (per-workspace):**
+
+| Workspace | Created By | Bundles | Size | Oldest | Newest | Modes |
+|---|---|---|---|---|---|---|
+| a3f8c2... | alice@example.com | 312 | 148.6 MB | 28d ago | 1h ago | 4 delta, 2 snapshot |
+| e91b07... | bob@example.com | 89 | 42.1 MB | 14d ago | 3d ago | 12 delta |
+
+- Created By: account with earliest `MIN(registered_at)` in `mailboxes` for
+  that workspace; `(unknown)` if mailbox was deleted.
+- Oldest bundle age flagged when within 3 days of `bundle_retention_days`.
+- Modes: count breakdown by `mode` column (invite/accept/snapshot/delta).
+- Workspace IDs truncated to 8 chars.
+- Sorted by bundle count descending.
+
+### Sessions
+
+**Dashboard line:**
+```
+Sessions: 18 active, oldest: 28d ago (expires in 2d), 3 accounts with active sessions
+```
+
+**Detail table (per-account):**
+
+| Account | Sessions | Newest | Oldest | Expires |
+|---|---|---|---|---|
+| alice@example.com | 3 | 1h ago | 14d ago | in 16d |
+| bob@example.com | 1 | 5d ago | 5d ago | in 25d |
+
+- Expires compared against `session_lifetime_seconds`; flags sessions expiring
+  within 24h.
+- Followed by challenge and password-reset summaries:
+
+```
+Challenges: 2 pending (1 registration, 1 device_add), oldest: 3m ago
+Password resets: 1 unused, expires in 48m
+```
+
+### Invites
+
+**Dashboard line:**
+```
+Invites: 12 active, 3.4 MB on disk, 47 total downloads
+```
+
+**Detail table:**
+
+| Token | Account | Size | Downloads | Created | Expires |
+|---|---|---|---|---|---|
+| f8a2c1... | alice@example.com | 1.2 MB | 14 | 3d ago | in 4d |
+| b91e07... | bob@example.com | 256 KB | 0 | 1h ago | in 7d |
+
+- Token truncated to 8 chars.
+- Flags invites expiring within 24h.
+- Sorted by `created_at` descending.
+
+### Health
+
+**Dashboard line:**
+```
+Health: DB 4.2 MB, blobs 892.4 MB, invites 3.4 MB, 8/8 migrations applied, WAL ok
+```
+
+**Detail view:**
+
+```
+=== DATABASE ===
+File:         storage/database/relay.sqlite (4.2 MB)
+Journal:      WAL ✓
+Foreign keys: ON ✓
+Migrations:   8/8 applied
+
+=== STORAGE ===
+Bundles dir:  892.4 MB (1,847 files)
+Invites dir:  3.4 MB (12 files)
+Total disk:   899.8 MB
+
+=== SETTINGS ===
+Bundle retention:     30 days
+Session lifetime:     30 days
+Challenge lifetime:   5 minutes
+Reset token lifetime: 1 hour
+Max bundle size:      10 MB
+Max storage/account:  100 MB
+Deletion grace:       90 days
+Min poll interval:    60 seconds
+```
+
+- Pragma values read via `PRAGMA journal_mode` and `PRAGMA foreign_keys`.
+- Migration count: compare files in `migrations/` against `_migrations` rows.
+- Blob file counts via `glob()` on storage directories.
+- Settings printed for quick reference.
+
+## Future Extensibility
+
+The subcommand structure allows adding write actions later, e.g.:
+
+```
+php bin/admin.php accounts delete <account_id>
+php bin/admin.php sessions revoke <token>
+php bin/admin.php bundles purge <workspace_id>
+```
+
+These would be additional branches in the dispatch logic — no structural changes
+needed.
+
+## Files Changed
+
+- **New**: `bin/admin.php` — the CLI tool (single file, no new classes)
+- **No changes** to existing code, dependencies, or schema.

--- a/docs/superpowers/specs/2026-03-15-cli-admin-tool-design.md
+++ b/docs/superpowers/specs/2026-03-15-cli-admin-tool-design.md
@@ -31,9 +31,11 @@ Unknown commands print an error plus the help text.
 $command = $argv[1] ?? 'dashboard';
 ```
 
-Each section is a standalone function: `showAccounts($pdo, $settings)`, etc.
-The `dashboard` command calls all section functions, which detect dashboard vs
-detail mode via a parameter (or by checking whether they were called directly).
+Each section is a standalone function with signature
+`showAccounts(PDO $pdo, array $settings, bool $detailed)`, etc.
+The `dashboard` command calls each function with `$detailed = false` (summary
+line only). Subcommands call their function with `$detailed = true` (summary
+line plus detail table).
 
 ## Output Format Conventions
 
@@ -68,7 +70,10 @@ Accounts: 42 total, 3 flagged for deletion, 1.2 GB total storage used
 | alice@example.com | 2 (2 verified) | 54.2 MB / 100 MB (54%) | — | 30d ago | 2h ago |
 | bob@example.com | 1 (0 verified) | 0 B / 100 MB (0%) | yes (12d ago) | 45d ago | never |
 
-- Storage compared against `max_storage_per_account_bytes`.
+- Storage reads `accounts.storage_used` (the DB column, not a live disk total).
+  Note: this value is recalculated by `cleanup.php` and may be stale between
+  cleanup runs if bundles have been deleted since the last run. Compared against
+  `max_storage_per_account_bytes`.
 - Device counts from JOIN on `device_keys` (total + verified).
 - Flagged shows time since flagging (relevant to `account_deletion_grace_days`).
 - Last Poll from `last_poll_at`; `never` if null.
@@ -83,14 +88,20 @@ Bundles: 1,847 pending, 892.4 MB on disk, oldest: 28d ago (expires in 2d)
 
 **Detail table (per-workspace):**
 
-| Workspace | Created By | Bundles | Size | Oldest | Newest | Modes |
+| Workspace | First Member | Bundles | Size | Oldest | Newest | Modes |
 |---|---|---|---|---|---|---|
 | a3f8c2... | alice@example.com | 312 | 148.6 MB | 28d ago | 1h ago | 4 delta, 2 snapshot |
 | e91b07... | bob@example.com | 89 | 42.1 MB | 14d ago | 3d ago | 12 delta |
 
-- Created By: account with earliest `MIN(registered_at)` in `mailboxes` for
-  that workspace; `(unknown)` if mailbox was deleted.
-- Oldest bundle age flagged when within 3 days of `bundle_retention_days`.
+- First Member: account with earliest `MIN(registered_at)` in `mailboxes` for
+  that workspace; `(unknown)` if all mailbox rows for the workspace have been
+  deleted. Note: due to `ON DELETE CASCADE`, if the original creator's account
+  was deleted, this shows the earliest *surviving* member — not necessarily the
+  workspace creator. Column header is "First Member" (not "Created By") to
+  reflect this.
+- Oldest bundle expiry computed as `created_at + bundle_retention_days` (from
+  settings). Flagged when within 3 days of expiry. If already past the
+  retention threshold (cleanup hasn't run yet), displays as `expired Xd ago!`.
 - Modes: count breakdown by `mode` column (invite/accept/snapshot/delta).
 - Workspace IDs truncated to 8 chars.
 - Sorted by bundle count descending.
@@ -109,8 +120,9 @@ Sessions: 18 active, oldest: 28d ago (expires in 2d), 3 accounts with active ses
 | alice@example.com | 3 | 1h ago | 14d ago | in 16d |
 | bob@example.com | 1 | 5d ago | 5d ago | in 25d |
 
-- Expires compared against `session_lifetime_seconds`; flags sessions expiring
-  within 24h.
+- Expires computed directly from `sessions.expires_at` (not derived from
+  `session_lifetime_seconds`, since the setting only applies at creation time).
+  Flags sessions expiring within 24h.
 - Followed by challenge and password-reset summaries:
 
 ```
@@ -133,7 +145,9 @@ Invites: 12 active, 3.4 MB on disk, 47 total downloads
 | b91e07... | bob@example.com | 256 KB | 0 | 1h ago | in 7d |
 
 - Token truncated to 8 chars.
-- Flags invites expiring within 24h.
+- Expires computed directly from `invites.expires_at` (the lifetime is baked in
+  at creation time; there is no config-level `invite_lifetime_seconds` setting).
+  Flags invites expiring within 24h.
 - Sorted by `created_at` descending.
 
 ### Health
@@ -170,6 +184,8 @@ Min poll interval:    60 seconds
 
 - Pragma values read via `PRAGMA journal_mode` and `PRAGMA foreign_keys`.
 - Migration count: compare files in `migrations/` against `_migrations` rows.
+  If any migrations are pending (files without matching rows), display as
+  `6/8 applied ⚠ 2 pending` to flag the mismatch.
 - Blob file counts via `glob()` on storage directories.
 - Settings printed for quick reference.
 

--- a/tests/Unit/Cli/AdminAccountsTest.php
+++ b/tests/Unit/Cli/AdminAccountsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\DeviceKeyRepository;
+
+final class AdminAccountsTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_accounts_dashboard_with_no_accounts(): void
+    {
+        ob_start();
+        showAccounts($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Accounts:', $output);
+        $this->assertStringContainsString('0 total', $output);
+    }
+
+    public function test_accounts_dashboard_with_data(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $repo->create('alice@example.com', 'hash', 'uuid1');
+        $repo->create('bob@example.com', 'hash', 'uuid2');
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('2 total', $output);
+    }
+
+    public function test_accounts_detail_shows_emails(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $repo->create('alice@example.com', 'hash', 'uuid1');
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('alice@example.com', $output);
+    }
+
+    public function test_accounts_detail_shows_device_counts(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $id = $repo->create('alice@example.com', 'hash', 'uuid1');
+
+        $dk = new DeviceKeyRepository($this->pdo);
+        $dk->add($id, 'pubkey1');
+        $dk->add($id, 'pubkey2');
+        $dk->markVerified('pubkey1');
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('2 (1 verified)', $output);
+    }
+
+    public function test_accounts_detail_shows_flagged(): void
+    {
+        $repo = new AccountRepository($this->pdo);
+        $id = $repo->create('alice@example.com', 'hash', 'uuid1');
+        $repo->flagForDeletion($id);
+
+        ob_start();
+        showAccounts($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('yes', $output);
+    }
+}

--- a/tests/Unit/Cli/AdminBundlesTest.php
+++ b/tests/Unit/Cli/AdminBundlesTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\DeviceKeyRepository;
+use Relay\Repository\MailboxRepository;
+use Relay\Repository\BundleRepository;
+
+final class AdminBundlesTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_bundles_dashboard_empty(): void
+    {
+        ob_start();
+        showBundles($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Bundles:', $output);
+        $this->assertStringContainsString('0 pending', $output);
+    }
+
+    public function test_bundles_dashboard_with_data(): void
+    {
+        $this->seedBundle('ws-1', 'sender-key', 'recipient-key', 'delta', 1024);
+
+        ob_start();
+        showBundles($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('1 pending', $output);
+    }
+
+    public function test_bundles_detail_shows_workspace(): void
+    {
+        $this->seedBundleWithMailbox(
+            'workspace-abc123def456',
+            'alice@example.com',
+            'delta',
+            2048
+        );
+
+        ob_start();
+        showBundles($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('workspac...', $output);
+        $this->assertStringContainsString('alice@example.com', $output);
+        $this->assertStringContainsString('1 delta', $output);
+    }
+
+    public function test_bundles_detail_unknown_first_member(): void
+    {
+        // Bundle exists but no mailbox for the workspace
+        $this->seedBundle('orphan-ws', 'sender', 'recipient', 'snapshot', 512);
+
+        ob_start();
+        showBundles($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('(unknown)', $output);
+    }
+
+    private function seedBundle(
+        string $workspaceId,
+        string $senderKey,
+        string $recipientKey,
+        string $mode,
+        int $size
+    ): void {
+        $bundleRepo = new BundleRepository($this->pdo);
+        $bundleId = bin2hex(random_bytes(16));
+        $bundleRepo->createWithId(
+            $bundleId,
+            $workspaceId,
+            $senderKey,
+            $recipientKey,
+            $mode,
+            $size,
+            "bundles/ab/{$bundleId}.swarm"
+        );
+    }
+
+    private function seedBundleWithMailbox(
+        string $workspaceId,
+        string $email,
+        string $mode,
+        int $size
+    ): void {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create($email, 'hash', 'uuid-' . bin2hex(random_bytes(4)));
+
+        $dk = new DeviceKeyRepository($this->pdo);
+        $pubkey = 'dk-' . bin2hex(random_bytes(8));
+        $dk->add($accountId, $pubkey);
+        $dk->markVerified($pubkey);
+
+        $mailboxRepo = new MailboxRepository($this->pdo);
+        $mailboxRepo->create($accountId, $workspaceId);
+
+        $this->seedBundle($workspaceId, $pubkey, $pubkey, $mode, $size);
+    }
+}

--- a/tests/Unit/Cli/AdminHealthTest.php
+++ b/tests/Unit/Cli/AdminHealthTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+
+final class AdminHealthTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_health_dashboard(): void
+    {
+        ob_start();
+        showHealth($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Health:', $output);
+        $this->assertStringContainsString('migrations applied', $output);
+    }
+
+    public function test_health_detail_shows_settings(): void
+    {
+        ob_start();
+        showHealth($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('=== SETTINGS ===', $output);
+        $this->assertStringContainsString('Bundle retention:', $output);
+        $this->assertStringContainsString('30 days', $output);
+        $this->assertStringContainsString('Max storage/account:', $output);
+        $this->assertStringContainsString('100.0 MB', $output);
+    }
+
+    public function test_health_detail_shows_migrations(): void
+    {
+        ob_start();
+        showHealth($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('=== DATABASE ===', $output);
+        $this->assertStringContainsString('Migrations:', $output);
+        // All 8 migrations should be applied
+        $this->assertStringContainsString('8/8 applied', $output);
+    }
+}

--- a/tests/Unit/Cli/AdminHelpersTest.php
+++ b/tests/Unit/Cli/AdminHelpersTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PHPUnit\Framework\TestCase;
+
+// We'll require the admin.php file and test its functions directly.
+// The functions will be defined in the global namespace inside bin/admin.php.
+
+final class AdminHelpersTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // Load the admin functions (the file guards against double-include
+        // and skips dispatch when included from tests).
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+    }
+
+    // --- humanBytes ---
+
+    public function test_human_bytes_zero(): void
+    {
+        $this->assertSame('0 B', humanBytes(0));
+    }
+
+    public function test_human_bytes_bytes(): void
+    {
+        $this->assertSame('512 B', humanBytes(512));
+    }
+
+    public function test_human_bytes_kilobytes(): void
+    {
+        $this->assertSame('1.5 KB', humanBytes(1536));
+    }
+
+    public function test_human_bytes_megabytes(): void
+    {
+        $this->assertSame('10.0 MB', humanBytes(10 * 1024 * 1024));
+    }
+
+    public function test_human_bytes_gigabytes(): void
+    {
+        $this->assertSame('2.3 GB', humanBytes(2469606195));
+    }
+
+    // --- relativeTime ---
+
+    public function test_relative_time_null(): void
+    {
+        $this->assertSame('never', relativeTime(null));
+    }
+
+    public function test_relative_time_seconds_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-30 seconds'));
+        $this->assertSame('just now', relativeTime($ts));
+    }
+
+    public function test_relative_time_minutes_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-5 minutes'));
+        $this->assertSame('5m ago', relativeTime($ts));
+    }
+
+    public function test_relative_time_hours_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-3 hours'));
+        $this->assertSame('3h ago', relativeTime($ts));
+    }
+
+    public function test_relative_time_days_ago(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-12 days'));
+        $this->assertSame('12d ago', relativeTime($ts));
+    }
+
+    // --- relativeTimeFuture ---
+
+    public function test_relative_time_future_minutes(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('+48 minutes'));
+        $this->assertSame('in 48m', relativeTimeFuture($ts));
+    }
+
+    public function test_relative_time_future_hours(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('+5 hours'));
+        $this->assertSame('in 5h', relativeTimeFuture($ts));
+    }
+
+    public function test_relative_time_future_days(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('+16 days'));
+        $this->assertSame('in 16d', relativeTimeFuture($ts));
+    }
+
+    public function test_relative_time_future_already_expired(): void
+    {
+        $ts = date('Y-m-d H:i:s', strtotime('-2 days'));
+        $this->assertSame('expired 2d ago!', relativeTimeFuture($ts));
+    }
+
+    // --- progressBar ---
+
+    public function test_progress_bar_normal(): void
+    {
+        $result = progressBar(54 * 1024 * 1024, 100 * 1024 * 1024);
+        $this->assertSame('54.0 MB / 100.0 MB (54%)', $result);
+    }
+
+    public function test_progress_bar_zero(): void
+    {
+        $result = progressBar(0, 100 * 1024 * 1024);
+        $this->assertSame('0 B / 100.0 MB (0%)', $result);
+    }
+
+    public function test_progress_bar_overflow(): void
+    {
+        $current = 112 * 1024 * 1024;
+        $max = 100 * 1024 * 1024;
+        $result = progressBar($current, $max);
+        $this->assertSame('112.0 MB / 100.0 MB (112%)', $result);
+    }
+}

--- a/tests/Unit/Cli/AdminInvitesTest.php
+++ b/tests/Unit/Cli/AdminInvitesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\InviteRepository;
+
+final class AdminInvitesTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_invites_dashboard_empty(): void
+    {
+        ob_start();
+        showInvites($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Invites:', $output);
+        $this->assertStringContainsString('0 active', $output);
+    }
+
+    public function test_invites_dashboard_with_data(): void
+    {
+        $this->seedInvite('alice@test.com', 2048, 5);
+
+        ob_start();
+        showInvites($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('1 active', $output);
+        $this->assertStringContainsString('5 total downloads', $output);
+    }
+
+    public function test_invites_detail_shows_token_and_account(): void
+    {
+        $this->seedInvite('alice@test.com', 1024, 0);
+
+        ob_start();
+        showInvites($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('alice@test.com', $output);
+        // Token should be truncated
+        $this->assertStringContainsString('...', $output);
+    }
+
+    private function seedInvite(string $email, int $size, int $downloads): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create($email, 'hash', 'uuid-' . bin2hex(random_bytes(4)));
+
+        $inviteRepo = new InviteRepository($this->pdo);
+        $inviteId = bin2hex(random_bytes(16));
+        $token = bin2hex(random_bytes(32));
+        $expiresAt = date('Y-m-d H:i:s', strtotime('+7 days'));
+        $inviteRepo->create($inviteId, $accountId, $token, "invites/ab/{$inviteId}.swarm", $size, $expiresAt);
+
+        // Simulate downloads
+        for ($i = 0; $i < $downloads; $i++) {
+            $inviteRepo->incrementDownloadCount($token);
+        }
+    }
+}

--- a/tests/Unit/Cli/AdminSessionsTest.php
+++ b/tests/Unit/Cli/AdminSessionsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Cli;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\SessionRepository;
+use Relay\Repository\ChallengeRepository;
+
+final class AdminSessionsTest extends TestCase
+{
+    private PDO $pdo;
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        require_once dirname(__DIR__, 3) . '/bin/admin.php';
+
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+
+        $this->settings = require dirname(__DIR__, 3) . '/config/settings.php';
+    }
+
+    public function test_sessions_dashboard_empty(): void
+    {
+        ob_start();
+        showSessions($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Sessions:', $output);
+        $this->assertStringContainsString('0 active', $output);
+    }
+
+    public function test_sessions_dashboard_with_data(): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create('alice@test.com', 'hash', 'uuid');
+
+        $sessionRepo = new SessionRepository($this->pdo);
+        $sessionRepo->create($accountId, 86400 * 30);
+
+        ob_start();
+        showSessions($this->pdo, $this->settings, false);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('1 active', $output);
+        $this->assertStringContainsString('1 accounts with active sessions', $output);
+    }
+
+    public function test_sessions_detail_shows_account(): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create('alice@test.com', 'hash', 'uuid');
+
+        $sessionRepo = new SessionRepository($this->pdo);
+        $sessionRepo->create($accountId, 86400 * 30);
+
+        ob_start();
+        showSessions($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('alice@test.com', $output);
+    }
+
+    public function test_sessions_shows_challenge_summary(): void
+    {
+        $accountRepo = new AccountRepository($this->pdo);
+        $accountId = $accountRepo->create('alice@test.com', 'hash', 'uuid');
+
+        $challengeRepo = new ChallengeRepository($this->pdo);
+        $challengeRepo->create($accountId, 'pubkey', 'nonce', 'serverpub', 'registration', 300);
+
+        ob_start();
+        showSessions($this->pdo, $this->settings, true);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Challenges:', $output);
+        $this->assertStringContainsString('1 pending', $output);
+        $this->assertStringContainsString('registration', $output);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,4 +2,6 @@
 
 declare(strict_types=1);
 
+define('PHPUNIT_RUNNING', true);
+
 require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary

- Adds `bin/admin.php` — a read-only CLI tool for inspecting the relay database and storage
- Implements 5 dashboard sections: accounts, bundles, sessions, invites, health
- Full dashboard (`php bin/admin.php`) plus per-section drill-downs with detail tables
- Includes helper functions: `humanBytes`, `relativeTime`, `relativeTimeFuture`, `progressBar`

## Test Plan

- [ ] 36 new unit tests across 5 test files in `tests/Unit/Cli/`
- [ ] All 88 tests pass (`php vendor/bin/phpunit`)
- [ ] `PHPUNIT_RUNNING` guard in `tests/bootstrap.php` allows `admin.php` to be loaded in tests without running DB bootstrap
- [ ] Smoke tested all subcommands: `accounts`, `bundles`, `sessions`, `invites`, `health`, `help`, unknown command (exits 1)