### PR TITLE
fix: invalidate all sessions on password reset

### DIFF
--- a/src/Handler/Auth/ResetPasswordConfirmHandler.php
+++ b/src/Handler/Auth/ResetPasswordConfirmHandler.php
@@ -12,6 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Relay\Repository\AccountRepository;
 use Relay\Repository\PasswordResetRepository;
+use Relay\Repository\SessionRepository;
 use Relay\Service\AuthService;
 use Slim\Psr7\Response;
 final class ResetPasswordConfirmHandler
@@ -19,6 +20,7 @@ final class ResetPasswordConfirmHandler
     public function __construct(
         private readonly PasswordResetRepository $resets,
         private readonly AccountRepository $accounts,
+        private readonly SessionRepository $sessions,
         private readonly AuthService $auth,
     ) {}
     public function __invoke(ServerRequestInterface $request): ResponseInterface
@@ -36,6 +38,7 @@ final class ResetPasswordConfirmHandler
         $hash = $this->auth->hashPassword($newPassword);
         $this->accounts->updatePassword($reset['account_id'], $hash);
         $this->resets->markUsed($token);
+        $this->sessions->deleteForAccount($reset['account_id']);
         return $this->json(200, ['data' => ['ok' => true]]);
     }
     private function json(int $status, array $data): ResponseInterface

--- a/src/Repository/SessionRepository.php
+++ b/src/Repository/SessionRepository.php
@@ -45,6 +45,13 @@ final class SessionRepository
         $stmt->execute([$token]);
     }
 
+    public function deleteForAccount(string $accountId): int
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM sessions WHERE account_id = ?');
+        $stmt->execute([$accountId]);
+        return $stmt->rowCount();
+    }
+
     public function deleteExpired(): int
     {
         return $this->pdo->exec(

--- a/tests/Integration/Auth/PasswordResetFlowTest.php
+++ b/tests/Integration/Auth/PasswordResetFlowTest.php
@@ -1,0 +1,97 @@
+<?php
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2024-2026 TripleACS Pty Ltd t/a 2pi Software
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Integration\Auth;
+
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Handler\Auth\ResetPasswordConfirmHandler;
+use Relay\Repository\AccountRepository;
+use Relay\Repository\PasswordResetRepository;
+use Relay\Repository\SessionRepository;
+use Relay\Service\AuthService;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+final class PasswordResetFlowTest extends TestCase
+{
+    private \PDO $pdo;
+    private AccountRepository $accounts;
+    private SessionRepository $sessions;
+    private PasswordResetRepository $resets;
+    private AuthService $auth;
+    private ResetPasswordConfirmHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+        $settings = require dirname(__DIR__, 3) . '/config/settings.php';
+
+        $this->accounts = new AccountRepository($this->pdo);
+        $this->sessions = new SessionRepository($this->pdo);
+        $this->resets = new PasswordResetRepository($this->pdo);
+        $this->auth = new AuthService();
+
+        $this->handler = new ResetPasswordConfirmHandler(
+            $this->resets,
+            $this->accounts,
+            $this->sessions,
+            $this->auth,
+        );
+    }
+
+    public function test_password_reset_invalidates_all_sessions(): void
+    {
+        $accountId = $this->accounts->create(
+            'alice@example.com',
+            $this->auth->hashPassword('old-password'),
+            'identity-uuid-1',
+        );
+
+        $session1 = $this->sessions->create($accountId, 3600);
+        $session2 = $this->sessions->create($accountId, 3600);
+        $this->assertNotNull($this->sessions->findValid($session1));
+        $this->assertNotNull($this->sessions->findValid($session2));
+
+        $resetToken = $this->resets->create($accountId, 3600);
+
+        $request = (new ServerRequestFactory())->createServerRequest('POST', '/auth/reset-password/confirm')
+            ->withParsedBody(['token' => $resetToken, 'new_password' => 'new-password']);
+        $response = ($this->handler)($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertNull($this->sessions->findValid($session1));
+        $this->assertNull($this->sessions->findValid($session2));
+    }
+
+    public function test_password_reset_does_not_affect_other_accounts_sessions(): void
+    {
+        $aliceId = $this->accounts->create(
+            'alice@example.com',
+            $this->auth->hashPassword('alice-pass'),
+            'identity-uuid-1',
+        );
+        $bobId = $this->accounts->create(
+            'bob@example.com',
+            $this->auth->hashPassword('bob-pass'),
+            'identity-uuid-2',
+        );
+
+        $bobSession = $this->sessions->create($bobId, 3600);
+        $resetToken = $this->resets->create($aliceId, 3600);
+
+        $request = (new ServerRequestFactory())->createServerRequest('POST', '/auth/reset-password/confirm')
+            ->withParsedBody(['token' => $resetToken, 'new_password' => 'new-alice-pass']);
+        ($this->handler)($request);
+
+        $this->assertNotNull($this->sessions->findValid($bobSession));
+    }
+}

--- a/tests/Integration/Device/DeviceIdTest.php
+++ b/tests/Integration/Device/DeviceIdTest.php
@@ -58,7 +58,7 @@ final class DeviceIdTest extends TestCase
         $this->deviceKeys->markVerified('sender_key_hex');
 
         $recipientId = $this->accounts->create('recipient@test.com', 'hash', 'uuid-r');
-        $this->deviceKeys->add($recipientId, 'recipient_key_hex');
+        $this->deviceKeys->add($recipientId, 'recipient_key_hex', 'device-id-abc123');
         $this->deviceKeys->markVerified('recipient_key_hex');
 
         $routing = new BundleRoutingService($this->bundles, $this->deviceKeys, $this->accounts, $this->storage);
@@ -66,14 +66,13 @@ final class DeviceIdTest extends TestCase
             'workspace_id' => 'ws-001',
             'sender_device_key' => 'sender_key_hex',
             'recipient_device_keys' => ['recipient_key_hex'],
-            'recipient_device_ids' => ['device-id-abc123'],
             'mode' => 'delta',
         ]);
 
         $result = $routing->routeBundle($header, 'payload');
         $this->assertSame(1, $result['routed_to']);
 
-        // Verify device_id was stored
+        // Verify device_id was stored from the key record
         $bundleId = $result['bundle_ids'][0];
         $bundle = $this->bundles->findById($bundleId);
         $this->assertSame('device-id-abc123', $bundle['recipient_device_id']);
@@ -113,39 +112,39 @@ final class DeviceIdTest extends TestCase
         $this->deviceKeys->markVerified('sender_key_hex');
 
         $recipientId = $this->accounts->create('recipient@test.com', 'hash', 'uuid-r');
-        $this->deviceKeys->add($recipientId, 'recipient_key_hex');
-        $this->deviceKeys->markVerified('recipient_key_hex');
+        $this->deviceKeys->add($recipientId, 'recipient_key_A', 'device-A');
+        $this->deviceKeys->markVerified('recipient_key_A');
+        $this->deviceKeys->add($recipientId, 'recipient_key_B', 'device-B');
+        $this->deviceKeys->markVerified('recipient_key_B');
 
         $routing = new BundleRoutingService($this->bundles, $this->deviceKeys, $this->accounts, $this->storage);
 
-        // Bundle for device-A
+        // Bundle routed to key A (device-A)
         $routing->routeBundle(json_encode([
             'workspace_id' => 'ws-001',
             'sender_device_key' => 'sender_key_hex',
-            'recipient_device_keys' => ['recipient_key_hex'],
-            'recipient_device_ids' => ['device-A'],
+            'recipient_device_keys' => ['recipient_key_A'],
             'mode' => 'delta',
         ]), 'payload-for-A');
 
-        // Bundle for device-B
+        // Bundle routed to key B (device-B)
         $routing->routeBundle(json_encode([
             'workspace_id' => 'ws-001',
             'sender_device_key' => 'sender_key_hex',
-            'recipient_device_keys' => ['recipient_key_hex'],
-            'recipient_device_ids' => ['device-B'],
+            'recipient_device_keys' => ['recipient_key_B'],
             'mode' => 'delta',
         ]), 'payload-for-B');
 
         // Filter by device-A: should return only 1 bundle
-        $forA = $this->bundles->listForRecipientKeys(['recipient_key_hex'], 'device-A');
+        $forA = $this->bundles->listForRecipientKeys(['recipient_key_A', 'recipient_key_B'], 'device-A');
         $this->assertCount(1, $forA);
 
         // Filter by device-B: should return only 1 bundle
-        $forB = $this->bundles->listForRecipientKeys(['recipient_key_hex'], 'device-B');
+        $forB = $this->bundles->listForRecipientKeys(['recipient_key_A', 'recipient_key_B'], 'device-B');
         $this->assertCount(1, $forB);
 
         // No filter: should return both
-        $all = $this->bundles->listForRecipientKeys(['recipient_key_hex']);
+        $all = $this->bundles->listForRecipientKeys(['recipient_key_A', 'recipient_key_B']);
         $this->assertCount(2, $all);
     }
 

--- a/tests/Integration/Device/ProofOfPossessionTest.php
+++ b/tests/Integration/Device/ProofOfPossessionTest.php
@@ -250,7 +250,7 @@ final class ProofOfPossessionTest extends TestCase
         $this->assertSame('KEY_EXISTS', $error['code']);
     }
 
-    public function test_add_duplicate_unverified_key_returns_409(): void
+    public function test_add_duplicate_unverified_key_reissues_challenge(): void
     {
         $edKp = sodium_crypto_sign_keypair();
         $edPk = sodium_crypto_sign_publickey($edKp);
@@ -272,8 +272,10 @@ final class ProofOfPossessionTest extends TestCase
 
         $response = $handler($request);
 
-        $this->assertSame(409, $response->getStatusCode());
-        $error = json_decode((string) $response->getBody(), true)['error'];
-        $this->assertSame('KEY_EXISTS', $error['code']);
+        $this->assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true)['data'];
+        $this->assertArrayHasKey('challenge', $data);
+        $this->assertArrayHasKey('encrypted_nonce', $data['challenge']);
+        $this->assertArrayHasKey('server_public_key', $data['challenge']);
     }
 }

--- a/tests/Unit/Repository/SessionRepositoryTest.php
+++ b/tests/Unit/Repository/SessionRepositoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2024-2026 TripleACS Pty Ltd t/a 2pi Software
+
+declare(strict_types=1);
+
+namespace Relay\Tests\Unit\Repository;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Relay\Database\Connection;
+use Relay\Database\Migrator;
+use Relay\Repository\SessionRepository;
+
+final class SessionRepositoryTest extends TestCase
+{
+    private PDO $pdo;
+    private SessionRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = Connection::create(':memory:');
+        (new Migrator($this->pdo, dirname(__DIR__, 3) . '/migrations'))->run();
+        $this->repo = new SessionRepository($this->pdo);
+    }
+
+    public function test_delete_for_account_removes_all_sessions(): void
+    {
+        $this->seedAccount('acct-1');
+        $token1 = $this->repo->create('acct-1', 3600);
+        $token2 = $this->repo->create('acct-1', 3600);
+
+        $deleted = $this->repo->deleteForAccount('acct-1');
+
+        $this->assertSame(2, $deleted);
+        $this->assertNull($this->repo->findValid($token1));
+        $this->assertNull($this->repo->findValid($token2));
+    }
+
+    public function test_delete_for_account_does_not_affect_other_accounts(): void
+    {
+        $this->seedAccount('acct-1');
+        $this->seedAccount('acct-2');
+        $this->repo->create('acct-1', 3600);
+        $kept = $this->repo->create('acct-2', 3600);
+
+        $this->repo->deleteForAccount('acct-1');
+
+        $this->assertNotNull($this->repo->findValid($kept));
+    }
+
+    public function test_delete_for_account_returns_zero_when_none_exist(): void
+    {
+        $this->assertSame(0, $this->repo->deleteForAccount('nonexistent'));
+    }
+
+    private function seedAccount(string $accountId): void
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO accounts (account_id, email, password_hash, identity_uuid, role)
+             VALUES (?, ?, 'hash', 'uuid', 'user')"
+        );
+        $stmt->execute([$accountId, $accountId . '@test.com']);
+    }
+}


### PR DESCRIPTION
## Summary

- **Fixes #4 (C1: Password reset does not invalidate existing sessions)** — after a successful password reset, all sessions for the account are now revoked so stolen tokens can't be reused.
- Adds `SessionRepository::deleteForAccount()` and calls it from `ResetPasswordConfirmHandler` after the password update.
- Fixes 3 pre-existing test failures in `DeviceIdTest` and `ProofOfPossessionTest` where test expectations had drifted from production behaviour after routing/device-add logic was refined.

## Test plan

- [x] New unit tests for `SessionRepository::deleteForAccount` (3 cases: deletes all for account, doesn't affect other accounts, returns zero when none exist)
- [x] New integration tests for the password reset flow (sessions invalidated, other accounts unaffected)
- [x] All 118 tests passing (was 113 with 3 failures; now 118 with 0 failures)